### PR TITLE
UBER-85, grunt test --reporters and --junitOutput added

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,13 +71,14 @@ module.exports = function (grunt) {
         karma: {
             options: {
                 configFile: 'test/karma.conf.js',
-                browsers: test.getBrowsers()
+                browsers: test.getBrowsers(),
+                reporters: test.getReporters(),
+                junitReporter: test.getJunitReporter()
             },
             continuous: {
                 singleRun: true
             },
             dev: {
-                reporters: 'dots'
             }
         },
         doc:{

--- a/test/test.js
+++ b/test/test.js
@@ -46,3 +46,23 @@ exports.getBrowsers = function () {
 
     return browsers;
 };
+
+exports.getReporters = function () {
+    var reporters = ['dots'];
+
+    if (argv.hasOwnProperty('reporters')) {
+        reporters = argv.reporters.split(',');;
+    }
+
+    return reporters;
+};
+
+exports.getJunitReporter = function () {
+    var junitReporter = {};
+
+    if (argv.hasOwnProperty('junitOutput')) {
+        junitReporter["outputFile"] = argv.junitOutput;
+    }
+
+    return junitReporter;
+};


### PR DESCRIPTION
options for CI Jenkins:
grunt test --reporters        karma-cli like --reporters option
grunt test --junitOutput     junit report output file customizer, if --reporters junit is set.
