### PR TITLE
Конфликтуют стили барона

### DIFF
--- a/src/DGCustomization/skin/basic/less/scroller.less
+++ b/src/DGCustomization/skin/basic/less/scroller.less
@@ -1,18 +1,18 @@
-.scroller {}
+.dg-scroller {}
 
-.scroller_hidden_true {
+.dg-scroller_hidden_true {
     overflow: auto;
     }
 
-.scroller::-webkit-scrollbar {
+.dg-scroller::-webkit-scrollbar {
     width: 0;
     }
 
-.scroller__wrapper {
+.dg-scroller__wrapper {
     position: relative;
     overflow: hidden;
     }
-    .scroller__bar-wrapper {
+    .dg-scroller__bar-wrapper {
         position: absolute;
         top: 18px;
         right: 3px;
@@ -20,13 +20,13 @@
         width: 7px;
         border-radius: 5px;
         }
-    .scroller_hidden_true .scroller__bar-wrapper {
+    .dg-scroller_hidden_true .scroller__bar-wrapper {
         visibility: hidden;
         }
-    .dg-popup__header + .dg-popup__container-wrapper .scroller__bar-wrapper {
+    .dg-popup__header + .dg-popup__container-wrapper .dg-scroller__bar-wrapper {
         top: 4px;
         }
-        .scroller__bar {
+        .dg-scroller__bar {
             position: absolute;
             min-height: 20px;
             width: 7px;

--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -194,9 +194,9 @@
                     this._initBaronScroller();
                     this._initBaron();
                 } else {
-                    DG.DomUtil.removeClass(this._scroller, 'scroller_hidden_true');
-                    DG.DomUtil.addClass(this._scroller, 'scroller_has-header_true');
-                    DG.DomUtil.addClass(this._scroller, 'scroller');
+                    DG.DomUtil.removeClass(this._scroller, 'dg-scroller_hidden_true');
+                    DG.DomUtil.addClass(this._scroller, 'dg-scroller_has-header_true');
+                    DG.DomUtil.addClass(this._scroller, 'dg-scroller');
                     if (scrollTop) {
                         this._scroller.scrollTop = scrollTop;
                     }
@@ -204,9 +204,9 @@
                 }
             } else {
                 if (this._isBaronExist) {
-                    DG.DomUtil.addClass(this._scroller, 'scroller_hidden_true');
-                    DG.DomUtil.removeClass(this._scroller, 'scroller_has-header_true');
-                    DG.DomUtil.removeClass(this._scroller, 'scroller');
+                    DG.DomUtil.addClass(this._scroller, 'dg-scroller_hidden_true');
+                    DG.DomUtil.removeClass(this._scroller, 'dg-scroller_has-header_true');
+                    DG.DomUtil.removeClass(this._scroller, 'dg-scroller');
                     DG.DomEvent.off(this._scroller, 'scroll', this._onScroll);
                 }
             }
@@ -249,12 +249,12 @@
 
         _initBaronScroller: function () {
             var contentNode = this._popupStructure.body.parentNode,
-                scrollerWrapper = this._scrollerWrapper =  DG.DomUtil.create('div', 'scroller__wrapper', contentNode),
-                scroller = this._scroller = DG.DomUtil.create('div', 'scroller', scrollerWrapper),
-                barWrapper = this._barWrapper = DG.DomUtil.create('div', 'scroller__bar-wrapper', scroller),
+                scrollerWrapper = this._scrollerWrapper =  DG.DomUtil.create('div', 'dg-scroller__wrapper', contentNode),
+                scroller = this._scroller = DG.DomUtil.create('div', 'dg-scroller', scrollerWrapper),
+                barWrapper = this._barWrapper = DG.DomUtil.create('div', 'dg-scroller__bar-wrapper', scroller),
                 innerHeight = this.options.maxHeight - this.options.border * 2;
 
-            this._scrollerBar = DG.DomUtil.create('div', 'scroller__bar', barWrapper);
+            this._scrollerBar = DG.DomUtil.create('div', 'dg-scroller__bar', barWrapper);
             scroller.appendChild(this._detachEl(this._popupStructure.body));
 
             innerHeight -= this._getDelta();
@@ -273,9 +273,9 @@
         _initBaron: function () {
             var context = this._scrollerWrapper;
             this._baron = graf({
-                scroller: '.scroller',
-                bar: '.scroller__bar',
-                track: '.scroller__bar-wrapper',
+                scroller: '.dg-scroller',
+                bar: '.dg-scroller__bar',
+                track: '.dg-scroller__bar-wrapper',
                 $: function (selector) {
                     var node = {}.toString.call(selector) === '[object String]' ?
                         context.querySelector(selector) : selector;

--- a/vendors/baron/baron.css
+++ b/vendors/baron/baron.css
@@ -1,29 +1,29 @@
 /* CSS styles in this file are need for proper Baron work */
-.wrapper {
+.dg-wrapper {
     position: relative;
     overflow: hidden;
 }
-.scroller {
+.dg-scroller {
     height: 100%;
     overflow-y: scroll;
     border: 0;
 }
-.scroller::-webkit-scrollbar { /* Preventing webkit bug of horizontal scrolling */
+.dg-scroller::-webkit-scrollbar { /* Preventing webkit bug of horizontal scrolling */
     width: 0;
 }
-.scroller__bar { /* The bar. You should define width, right and background */
+.dg-scroller__bar { /* The bar. You should define width, right and background */
     position: absolute;    
     z-index: 1;
     right: 0;
     width: 10px;
     background: #999;
 }
-.scroller__bar_h {
+.dg-scroller__bar_h {
     bottom: 2px;
     height: 8px;
 }
 
-.header__title {
+.dg-header__title {
     width: 100%;
     margin: 0;
     -moz-box-sizing: border-box;
@@ -32,7 +32,7 @@
 
     /* pointer-events: none; /* IE9+ https://developer.mozilla.org/en-US/docs/CSS/pointer-events */
 }
-.header__title_state_fixed {
+.dg-header__title_state_fixed {
     position: absolute;
     z-index: 1; /* Removing flicker effect */
 }


### PR DESCRIPTION
У нас сейчас в css отдаются такие стили как:

``` css
.wrapper {
    overflow: hidden;
    position: relative;
}
```

не очень хорошо, уже конфликтуем. Надо завернуть классы типо _.wrapper_ в наш неймспейс.
