### PR TITLE
Ошибка загрузки картинок в API 2.0 в IE8

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -26,6 +26,8 @@
     "GA_CODE": "UA-38243181-2",
 
     "RELATIVE_URL": {
+        "SPRITES_URL": "//maps.api.2gis.ru/2.0",
+
         "TILE_SERVER": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
 
         "TRAFFIC_TILE_SERVER": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -463,7 +463,7 @@ gulp.task('collect-images-usage-stats', ['clean-up-tmp-less'], function (cb) {
                         variables: {
                             skinName: skinName,
                             baseURL: '\'__BASE_URL__\'',
-                            baseIEURL: '"http://maps.api.2gis.ru/2.0"',
+                            spritesURL: '\'__SPRITES_URL__\'',
 
                             mobile: false,
                             ie8: true,
@@ -572,8 +572,8 @@ function buildCss(options, enableSsl) {
 
     lessPrerequirements = deps.lessHeader({
         variables: {
-            baseURL: '"__BASE_URL__"',
-            baseIEURL: '"http://maps.api.2gis.ru/2.0"',
+            baseURL: '\'__BASE_URL__\'',
+            spritesURL: '\'__SPRITES_URL__\'',
 
 
             mobile: options.mobile,

--- a/private/less/mixins.ie8.less
+++ b/private/less/mixins.ie8.less
@@ -13,5 +13,5 @@
     }
 
 .alphaImage(@name; @sizingMethod: scale) {
-    filter: e("progid:DXImageTransform.Microsoft.AlphaImageLoader(src='@{baseIEURL}/img/@{name}.png',sizingMethod='@{sizingMethod}')");
+    filter: e("progid:DXImageTransform.Microsoft.AlphaImageLoader(src='@{spritesURL}/img/@{name}.png',sizingMethod='@{sizingMethod}')");
     }

--- a/private/less/mixins.less
+++ b/private/less/mixins.less
@@ -20,7 +20,7 @@
     width: @width;
     height: @height;
 
-    background-image: url('@{baseIEURL}/img/@{backgroundImage}');
+    background-image: url('@{spritesURL}/img/@{backgroundImage}');
 
     background-position: @backgroundPosition;
     background-size: @totalWidth @totalHeight;


### PR DESCRIPTION
Файл стилей:
http://maps.api.2gis.ru/2.0/css/?pkg=full&skin=light&ie8=true&sprite=true&version=v2.0.25

В нем есть стили контролов вида
.dg-control-round{
   filter:progid:DXImageTransform.Microsoft.AlphaImageLoader(src='/2.0/img/DGRoundControl__button_light.png', sizingMethod='scale') }

IE 8 вместо загрузки картинок с хоста http://maps.api.2gis.ru/ грузит их с хоста, куда подключены карты.
