### PR TITLE
Бутстрап ломает наши контролы

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -19,6 +19,9 @@ var deps = {
             'DGCore/src/DGthen.js',
             'DGCore/src/DGplugin.js'
         ],
+        less: {
+            all: ['DGCore/skin/basic/less/dg-core.less']
+        },
         heading: '2GIS modules',
         deps: ['Leaflet']
     },

--- a/src/DGAttribution/skin/basic/less/dg-mapcopyright.less
+++ b/src/DGAttribution/skin/basic/less/dg-mapcopyright.less
@@ -21,16 +21,17 @@
                 list-style-type: none;
                 }
                 .leaflet-container .dg-attribution__link {
-                    background: linear-gradient(to right, rgba(8, 8, 8, 0.3), rgba(8, 8, 8, 0.3) 100%) 0 95% repeat-x transparent;
+                    background: linear-gradient(to right, rgba(8, 8, 8, 0.3), rgba(8, 8, 8, 0.3) 100%) 0 95% repeat-x;
                     background-size: 10px 1px;
                     color: #333;
                     text-decoration: none;
                     font: 9px/12px Helvetica, Arial, sans-serif;
                     cursor: pointer;
 
-                    .no-touch &:hover {
+                    &:hover {
                         background-image: linear-gradient(to right, #080808, #080808 100%);
                         color: #333;
+                        text-decoration: none;
                         }
                     }
 

--- a/src/DGCore/skin/basic/less/dg-core.less
+++ b/src/DGCore/skin/basic/less/dg-core.less
@@ -1,0 +1,10 @@
+
+[class^="dg-"],
+[class^="dg-"]:before,
+[class^="dg-"]:after {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    font-size: 1em;
+    line-height: 1;
+    }


### PR DESCRIPTION
Выставляет правило:

```
 * {
-webkit-box-sizing: border-box;
-moz-box-sizing: border-box;
box-sizing: border-box;
}
```

И все скукоживается, как по ссылке:

http://az.falsecode.ru/?NAME=&BRAND=0&STATUS=0&OEM=&MODEL=0&FRONT_REAR=0&ARTIKUL=&BODY=&LEFT_RIGHT=0&YEAR_START=&YEAR_END=&UP_DOWN=0&ENGINE=&WHEEL_SIDE=0&SELLER=0&map=Y#adv
