### PR TITLE
Прикрутить code coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+repo_token: va64PLOmYsCCJltbYFV2gJEjYaoa9f5uN

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,3 @@ install:
 
 script:
   - gulp test
-
-notifications:
-  slack: api2gis:MAMEvjiPaeHZESLerOKePKQq

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-API карт 2GIS
+API карт 2GIS [![Build Status](https://travis-ci.org/2gis/mapsapi.svg?branch=master)](https://travis-ci.org/2gis/mapsapi) [![Coverage Status](https://img.shields.io/coveralls/2gis/mapsapi.svg)](https://coveralls.io/r/2gis/mapsapi)
 ====
 
 При помощи API карт вы сможете:


### PR DESCRIPTION
Есть сервис coveralls, который работает совместно с travis.
Надо описать конфиг-файл, чтобы он работал с нашим проектом.

Бонус: убрать slack чат из тревиса для оповещений.
