### PR TITLE
Отображение пустого атрибута адреса у балуна

### DIFF
--- a/src/DGGeoclicker/skin/basic/less/dg-building-callout.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-building-callout.less
@@ -1,7 +1,8 @@
 .dg-building-callout__body {
     position: relative;
-    
-    &:first-child:before {
+    }
+
+    .dg-map-geoclicker__address:before {
         position: absolute;
         top: 1px;
         left: 0px;
@@ -10,7 +11,6 @@
         background-size: contain;
         content: '';
         }
-    }
 
     .dg-building-callout__list {
         margin: 8px 8px 8px 24px;
@@ -22,7 +22,7 @@
             position: relative;
             margin: 0 0 4px;
             font: 12px/16px Arial, sans-serif;
-            
+
             &:before {
                 position: absolute;
                 top: 6px;

--- a/src/DGGeoclicker/skin/basic/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-map-geoclicker.less
@@ -1,17 +1,16 @@
 .dg-map-geoclicker__address {
+    position: relative;
     padding: 0 0 0 24px;
-    color: #aaa;
     font: 12px/16px Arial, sans-serif;
     }
 
 .dg-map-geoclicker__address-header {
-    position: relative;
-    margin: 6px 0 2px 24px;
+    margin: 6px 0 2px;
     font: 16px/16px Arial, sans-serif;
     }
 
-.dg-map-geoclicker__drilldown {
-    padding: 0 0 0 24px;
+.dg-map-geoclicker__address-drilldown {
+    color: #aaa;
     font: 12px/16px Arial, sans-serif;
     }
 

--- a/src/DGGeoclicker/skin/dark/less/dg-building-callout.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-building-callout.less
@@ -1,4 +1,4 @@
-.dg-building-callout__body:first-child:before {
+.dg-map-geoclicker__address:before {
     .noRepeatableBg('DGBuildingCallout__marker_dark');
     }
 .dg-building-callout__list-item:before {

--- a/src/DGGeoclicker/skin/light/less/dg-building-callout.less
+++ b/src/DGGeoclicker/skin/light/less/dg-building-callout.less
@@ -1,4 +1,4 @@
-.dg-building-callout__body:first-child:before {
+.dg-map-geoclicker__address:before {
     .noRepeatableBg('DGBuildingCallout__marker_light');
     }
 .dg-building-callout__list-item:before {

--- a/src/DGGeoclicker/src/handler/House.View.js
+++ b/src/DGGeoclicker/src/handler/House.View.js
@@ -19,10 +19,17 @@ DG.Geoclicker.Handler.House.include({
             wrapper = DG.DomUtil.create('div', 'dg-building-callout__body'),
             filials = house.links.branches;
 
-        data.drilldown = this._getDrilldown(house);
+        var drilldown = this._getDrilldown(house);
 
         if (house.building_name) {
-            data.address = this._getAddressString(house);
+            data.address = {
+                header: this._getAddressString(house),
+                drilldown: drilldown
+            };
+        } else if (drilldown) {
+            data.address = {
+                drilldown: drilldown
+            };
         }
 
         data.purpose = house.purpose_name +

--- a/src/DGGeoclicker/templates/house.dust
+++ b/src/DGGeoclicker/templates/house.dust
@@ -1,12 +1,19 @@
 {#address}
-    <div class="dg-map-geoclicker__address-header">{.}</div>
+<address class="dg-map-geoclicker__address">
+	{#address.header}
+	    <div class="dg-map-geoclicker__address-header">{.}</div>
+	{/address.header}
+
+	{#address.drilldown}
+	    <div class="dg-map-geoclicker__drilldown">{.}</div>
+	{/address.drilldown}
+</address>
 {/address}
-{#drilldown}
-    <div class="dg-map-geoclicker__drilldown">{.}</div>
-{/drilldown}
+
 {#purpose}
 	<div class="dg-map-geoclicker__purpose">{.}</div>
 {/purpose}
+
 {#attractions}
     <div class="dg-map-geoclicker__purpose dg-map-geoclicker__purpose_type_sight">{.}</div>
 {/attractions}

--- a/src/DGGeoclicker/templates/sight.dust
+++ b/src/DGGeoclicker/templates/sight.dust
@@ -1,12 +1,19 @@
 {#purpose}
 	<div class="dg-map-geoclicker__purpose dg-map-geoclicker__purpose_type_sight">{.}</div>
 {/purpose}
+
 {#address}
-    <div class="dg-map-geoclicker__address">{.}</div>
+<address class="dg-map-geoclicker__address">
+	{#address.header}
+	    <div class="dg-map-geoclicker__address-header">{.}</div>
+	{/address.header}
+
+	{#address.drilldown}
+	    <div class="dg-map-geoclicker__drilldown">{.}</div>
+	{/address.drilldown}
+</address>
 {/address}
-{#drillDown}
-	<div class="dg-map-geoclicker__drilldown">{.}</div>
-{/drillDown}
+
 {#description}
     <div class="dg-map-geoclicker__sight-description">{.}</div>
     {#showMoreText}


### PR DESCRIPTION
При открытии балуна с пустым атрибутом адреса, отображается путой атрибут с иконкой которая наезжает на иконку описания.
![selection_010](https://cloud.githubusercontent.com/assets/9331669/5024080/16bfdde8-6b26-11e4-9872-b30a15389e72.png)
[Ссылка на пример в онлайне](http://2gis.ru/novosibirsk/callout/82.768925%2C54.972681%2C18/center/82.769111%2C54.972141/zoom/18)
