### PR TITLE
DG.then "съедает" ошибки

### DIFF
--- a/src/DGCore/src/DGthen.js
+++ b/src/DGCore/src/DGthen.js
@@ -2,9 +2,9 @@ var handlers = window.__dgApi__.callbacks || [],
     chain = Promise.resolve();
 
 //dont pollute global space!
-try { 
+try {
     delete window.__dgApi__; 
-} catch(e) { 
+} catch(e) {
     window.__dgApi__ = undefined; //ie8 cant delete from window object
 }
 
@@ -15,3 +15,7 @@ handlers.forEach(function (handlers) {
 DG.then = function (resolve, reject) {
     return chain.then(resolve, reject);
 };
+
+chain.catch(function(err) {
+    console.error(err);
+});


### PR DESCRIPTION
Т.к. до загрузки основного скрипта `DG.then` не промис, а просто функция, которая складирует вызовы, то решили сделать так.

Накосячил и не переделал ишью https://github.com/2gis/mapsapi/issues/15 в пулл реквест
