### PR TITLE
Не работает pkg=basic

### DIFF
--- a/build/packs.js
+++ b/build/packs.js
@@ -3,7 +3,7 @@ var packages = {
     basic: {
         name: 'Basic package',
         desc: 'Provides basic functionality: map, markers, popups, geometries',
-        modules: ['DGCustomization', 'DGTileLayer', 'DGFullScreen', 'DGAttribution']
+        modules: ['DGCustomization', 'DGTileLayer', 'DGFullScreen', 'DGAttribution', 'DGAjax']
     },
 
     full: {


### PR DESCRIPTION
При подключении карты с опцией pkg=basic не работает карта
