### PR TITLE
Маленький div height при добавлении геометрий на карту ломает загрузку тайлов

### DIFF
--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -40,7 +40,6 @@ DG.Map.include({
 
         this._layers = {};
         this._zoomBoundLayers = {};
-        this._tileLayersNum = 0;
 
         this.callInitHooks();
 
@@ -49,6 +48,8 @@ DG.Map.include({
         if (options.center && options.zoom !== undefined) {
             this.setView(L.latLng(options.center), options.zoom, {reset: true});
         }
+
+        this._sizeChanged = true;
     },
 
     setView: function (center, zoom, options) {


### PR DESCRIPTION
При добавлении геометрий на карту по [доке](http://api.2gis.ru/doc/maps/examples/geometries/) если div height меньше некоторого значения возникают ситуации когда не прогружаются тайлы
Баг получен в Chrome 38, нода с которой подключено API не пренципиально ( c maps.api.2gis.ru ситуация та же )

``` HTML
<!DOCTYPE html>
<html>
    <head>
        <meta charset="utf-8" />
        <title>Отображение прямоугольников</title>
        <script src="http://127.0.0.1:3001/loader.js"
        data-id="dgLoader"></script>
    </head>
    <body>
        <div id="map" style="width: 100%; height: 300px;"></div>
        <script>
            DG.then(function() {
                var map,
                    coords1 = [[54.98, 82.87], [54.975, 82.91]],
                    coords2 = [[54.985, 82.87], [54.982, 82.91]],
                    coords3 = [[54.99, 82.87], [54.987, 82.91]],
                    coords4 = [[54.995, 82.87], [54.992, 82.91]],
                    rectangles = DG.featureGroup();
                map = DG.map('map', {
                    center: [54.98, 82.89],
                    zoom: 14
                });
                // Добавление прямоугольников в группу
                DG.rectangle(coords1, {color: "blue"}).addTo(rectangles);
                DG.rectangle(coords2, {color: "red"}).addTo(rectangles);
                DG.rectangle(coords3, {color: "green"}).addTo(rectangles);
                DG.rectangle(coords4, {color: "gray"}).addTo(rectangles);
                // Добавление группы на карту
                rectangles.addTo(map);
                // Подстройка границ карты
                map.fitBounds(rectangles.getBounds());
            });
        </script>
    </body>
</html>
```

![selection_009](https://cloud.githubusercontent.com/assets/9331669/5005674/54e4c772-6a55-11e4-937e-252f7dbb712c.png)
