### PR TITLE
API не работает по https

### DIFF
--- a/private/loader.js
+++ b/private/loader.js
@@ -144,6 +144,10 @@
     function loadProjectList() {
         var url = '__WEB_API_SERVER__/__WEB_API_VERSION__/region/list';
 
+        // При необходимости меняем у ссылки протокол
+        var protocol = window.location.protocol == 'http:' ? 'http:' : 'https:';
+        url = url.replace(/^https?:/, protocol);
+
         return new Promise(function (resolve, reject) {
             DG.ajax(url, {
                 type: 'get',


### PR DESCRIPTION
Не работает бой по [https](https://maps.api.2gis.ru/2.0/). В консоль выкидывает ошибку:

```
[blocked] The page at 'https://maps.api.2gis.ru/2.0/' was loaded over HTTPS, but ran insecure content from 'http://catalog.api.2gis.ru/2.0/region/list?key=rujrdp3400&fields=items.boun…s.time_zone%2Citems.code%2Citems.flags%2Citems.country_code%2Citems.domain': this content should also be loaded over HTTPS.
 ?sprite=false&version=v2.0.29:10getRequest ?sprite=false&version=v2.0.29:10(anonymous function) ?sprite=false&version=v2.0.29:10doRequest ?sprite=false&version=v2.0.29:10Ajax ?sprite=false&version=v2.0.29:10(anonymous function) loader.js:1f loader.js:1
```

Союираю nginx`ы для заготовки стенда.
