### PR TITLE
Повысил timeout тестов в карме до 15 секунд

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
 
         client: {
             mocha: {
-                timeout: 5000
+                timeout: 15000
             }
         },
 


### PR DESCRIPTION
Повысил `timeout` тестов в карме до 15 секунд.

Тест лифлета на `L.Util.requestAnimFrame` выполнялся дольше 5000ms и тесты не тревисе сыпались. Вопрос, почему этот тест стал долго выполняться, остаётся открытым.
