### PR TITLE
Выпилить модуль cluster из package.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,7 +62,7 @@ var host = app.get('host'),
 
 if (cluster.isMaster) {
     cluster
-        .on('death', function (worker) {
+        .on('disconnect', function (worker) {
             console.log('PID #' + worker.process.pid + ' died. spawning a new process...');
             cluster.fork();
         })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "chalk": "0.4.0",
     "cli-color": "0.3.2",
-    "cluster": "0.7.7",
     "cors": "^2.4.1",
     "dustjs-linkedin": "2.3.1",
     "event-stream": "3.1.0",


### PR DESCRIPTION
1. Модуль `cluster` указанный в `package.json` не используется, вместо него используется родной модуль nodejs.
2. В nodejs версии 10 у модуля `cluster` нет события `death`, есть `disconnect`, возможно, стоит заменить.
