### PR TITLE
Колаут балуна фирмы повисает на прелоадере

### DIFF
--- a/vendors/firmcard/src/FirmCard.js
+++ b/vendors/firmcard/src/FirmCard.js
@@ -197,9 +197,11 @@ FirmCard.prototype = {
             });
         }
 
-        if (this._firmData.links &&
-            this._firmData.links.entrances &&
-            this.options.showEntrance) {
+        if (
+            this._firmData.links &&
+                this._firmData.links.entrances &&
+                this.options.showEntrance
+        ) {
             btns.push({ name: 'show-entrance',
                         label: this.dict.t(this.options.lang, 'btnEntrance'),
                         icon: true


### PR DESCRIPTION
Баг на бою.
При открытии балуна фирмы в гаражном кооперативе "Луч" повисает на преладере
Steps:
1.Открываем бой
2.Кликаем Римского-Корсакова 11/1
3.Кликаем на фирму
Результат:
Повисающий прелоадер.
Скрин (спустя некоторое время):
![selection_011](https://cloud.githubusercontent.com/assets/9331669/5042529/95290a56-6bf8-11e4-92b7-525251c28a49.png)

Приехавший XHR:
[По клику в фирму](http://catalog.api.2gis.ru/2.0/catalog/branch/get?key=ruxlih0718&type=filial&id=141265770856476&fields=items.reviews%2Citems.photos%2Citems.links%2Citems.booklet)
[По клику в здание](http://catalog.api.2gis.ru/2.0/geo/search?key=ruxlih0718&point=82.8870874643326%2C54.97861420987662&type=adm_div.settlement%2Cadm_div.city%2Cadm_div.division%2Cadm_div.district%2Cstreet%2Cbuilding%2Cadm_div.place%2Cpoi%2Cattraction&zoom_level=18&fields=items.geometry.selection%2Citems.links%2Citems.adm_div%2Citems.address%2Citems.floors%2Citems.description)

[Ссылка на онлайн](http://2gis.ru/novosibirsk/firm/141265770856476/center/82.886135%2C54.978483/zoom/18)
