### PR TITLE
Клик при драге в FF

### DIFF
--- a/src/DGMeta/src/DGMeta.Layer.js
+++ b/src/DGMeta/src/DGMeta.Layer.js
@@ -127,7 +127,7 @@ DG.Meta.Layer = DG.Layer.extend({
                 latlng: this._map.mouseEventToLatLng(mouseEvent)
             });
             if (this.options.eventBubbling === 'layer') {
-                DG.DomEvent.stop(event);
+                DG.DomEvent.stop(mouseEvent);
             }
         }
     },


### PR DESCRIPTION
Порядок воспроизведения:
1.Открыть http://maps.api.2gis.ru/2.0/ в FF
2.Закрыть балун
3.Призумиться до появления первых POI
4.Навести курсор на POI до появления тултипа
5.Изменить zoom(увеличить или уменьшить, не принципиально)
6.Подрагать карту
ОР: карта драгается
ФР:карта драгается, но после драга проскакивает клик по карте
UPD: Firebug при этом пестрит ошибками
