### PR TITLE
Не кликабельны attractions в здании

### DIFF
--- a/src/DGGeoclicker/src/Controller.js
+++ b/src/DGGeoclicker/src/Controller.js
@@ -5,10 +5,8 @@ DG.Geoclicker.Controller = DG.Class.extend({
         // default handler always should return rendering object
         'handlersSequence': {
             'poi': DG.Geoclicker.Handler.Poi,
-            'building': DG.Geoclicker.Handler.House,
-
             'attraction': DG.Geoclicker.Handler.Sight,
-
+            'building': DG.Geoclicker.Handler.House,
             'street': DG.Geoclicker.Handler.CityArea,
             'adm_div.place': DG.Geoclicker.Handler.CityArea,
             'adm_div.district': DG.Geoclicker.Handler.CityArea,


### PR DESCRIPTION
Баг на бою.
При наличии достопремичательности в здании она не кликабельна.
Не путать со [зданием достопремичательностью](https://github.com/2gis/mapsapi/pull/24#issuecomment-61964382)
Примеры:
Ссылки на онлайн
[Клик в здание](http://2gis.ru/novosibirsk/callout/82.871327%2C54.993355%2C18/center/82.872359%2C54.992642/zoom/18)
[Клик в достопремичательность](http://2gis.ru/novosibirsk/callout/82.871375%2C54.993308%2C18/center/82.872359%2C54.992642/zoom/18)
Приехавший [XHR](http://catalog.api.2gis.ru/2.0/geo/search?key=ruxlih0718&point=82.8713643550873%2C54.99331156538629&type=adm_div.settlement%2Cadm_div.city%2Cadm_div.division%2Cadm_div.district%2Cstreet%2Cbuilding%2Cadm_div.place%2Cpoi%2Cattraction&zoom_level=18&fields=items.geometry.selection%2Citems.links%2Citems.adm_div%2Citems.address%2Citems.floors%2Citems.description)
