### PR TITLE
Коллаут здания зависает на прелоадере

### DIFF
--- a/src/DGGeoclicker/src/handler/House.View.js
+++ b/src/DGGeoclicker/src/handler/House.View.js
@@ -86,8 +86,8 @@ DG.Geoclicker.Handler.House.include({
 
         // Decide if we need to display 'more organisations' button
         if (
-            houseFilials.count > 0 &&
             houseFilials.items &&
+            houseFilials.items.length &&
             houseFilials.count > houseFilials.items.length
         ) {
             btns.push(this._getShowAllData(houseFilials.count));


### PR DESCRIPTION
Фикс бага с Блюхера, 36.

Теперь, если в ответе `geo/search` для здания в разделе фирм `count > 0`, но массив `items` отсутствует, кнопку «Всего организаций» мы не показываем.
