### PR TITLE
Загружать стили AJAX-запросом

### DIFF
--- a/private/loader.js
+++ b/private/loader.js
@@ -139,13 +139,15 @@
                 dataType: 'html',
 
                 success: function (data) {
-                    if (style.styleSheet){
+                    var head = document.getElementsByTagName('head')[0];
+
+                    if (style.styleSheet) {
+                        head.appendChild(style);
                         style.styleSheet.cssText = data;
                     } else {
                         style.appendChild(document.createTextNode(data));
+                        head.appendChild(style);
                     }
-
-                    document.getElementsByTagName('head')[0].appendChild(style);
 
                     resolve();
                 },


### PR DESCRIPTION
После пулл-реквеста #110 из-за нюансов в реализации события `DOMContentLoaded` в Firefox и Safari опять стал проявляться баг с медленной загрузкой CSS.

Теперь стили карты загружаются с помощью `DG.ajax` и помещаются на страницу в теге `<style>`. В итоге получаем:
1. Железную уверенность в том, что стили загружены (пока не загрузятся, не резолвится промис)
2. Полноценную ленивую загрузку
3. Не надо дожидаться события `window.onload`
