### PR TITLE
Нет испанских переводов для коллаутов фирм

### DIFF
--- a/vendors/firmcard/src/Dictionary.js
+++ b/vendors/firmcard/src/Dictionary.js
@@ -367,7 +367,7 @@ FirmCard.prototype.dict = {
         isClosingOnDinner : 'začíná polední přestávka'
     },
 
-    sp: {
+    es: {
         pluralRules: function (n) { // (Number)
           return (n === 1) ? 0 : (n >= 2 && n <= 4) ? 1 : 2;
         },


### PR DESCRIPTION
Если для карты указан испанский язык, то в коллаутах фирм надписи всё равно отображаются на русском.

Посмотреть можно, например, на http://firmsonmap.2gis.cl/, кликнув в любую POI фирмы.