### PR TITLE
Closing popups by tap on the map

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -59,6 +59,7 @@ var deps = {
             'DGCustomization/skin/basic/skin.config.js',
             '../vendors/baron/baron.js',
             'DGCustomization/src/DGCustomization.js',
+            'DGCustomization/src/DGMap.Tap.js',
             'DGCustomization/src/DGPopup.js',
             'DGCustomization/src/DGZoom.js',
             'DGCustomization/lang/DGZoom/ru.js',

--- a/src/DGCustomization/src/DGMap.Tap.js
+++ b/src/DGCustomization/src/DGMap.Tap.js
@@ -1,0 +1,33 @@
+DG.Map.Tap.include({
+    _onUp: function (e) {
+        clearTimeout(this._holdTimeout);
+
+        L.DomEvent.off(document, {
+            touchmove: this._onMove,
+            touchend: this._onUp
+        }, this);
+
+        if (this._fireClick && e && e.changedTouches) {
+
+            var first = e.changedTouches[0],
+                el = first.target;
+
+            if (el && el.tagName && el.tagName.toLowerCase() === 'a') {
+                L.DomUtil.removeClass(el, 'leaflet-active');
+            }
+
+            this._simulateEvent('mouseup', first);
+
+            // simulate click if the touch didn't move too much
+            if (this._isTapValid()) {
+                // close popup and don't simulate click if popup is open
+                // https://github.com/2gis/mapsapi/issues/96
+                if (this._map._popup) {
+                    this._map.closePopup();
+                } else {
+                    this._simulateEvent('click', first);
+                }
+            }
+        }
+    }
+});

--- a/src/DGCustomization/src/DGZoom.js
+++ b/src/DGCustomization/src/DGZoom.js
@@ -35,6 +35,7 @@ DG.Control.Zoom.include({
         this._zoomOutButton.title = this.t('zoom_out');
     },
 
+    // add touchend event because tap don't work on controls when popup is open
     _createButton: function (html, title, className, container, fn) {
         var link = L.DomUtil.create('a', className, container);
         link.innerHTML = html;

--- a/src/DGCustomization/src/DGZoom.js
+++ b/src/DGCustomization/src/DGZoom.js
@@ -33,5 +33,22 @@ DG.Control.Zoom.include({
     _renderTranslation: function () {
         this._zoomInButton.title = this.t('zoom_in');
         this._zoomOutButton.title = this.t('zoom_out');
+    },
+
+    _createButton: function (html, title, className, container, fn) {
+        var link = L.DomUtil.create('a', className, container);
+        link.innerHTML = html;
+        link.href = '#';
+        link.title = title;
+
+        var clickEvent = DG.Browser.touch ? 'click touchend' : 'click';
+
+        L.DomEvent
+            .on(link, 'mousedown dblclick', L.DomEvent.stopPropagation)
+            .on(link, clickEvent, L.DomEvent.stop)
+            .on(link, clickEvent, fn, this)
+            .on(link, clickEvent, this._refocusOnMap, this);
+
+        return link;
     }
 });

--- a/src/DGRoundControl/src/DGRoundControl.js
+++ b/src/DGRoundControl/src/DGRoundControl.js
@@ -28,8 +28,10 @@ DG.RoundControl = DG.Control.extend({
 
         this._map = map;
 
+        var clickEvent = DG.Browser.touch ? 'click touchend' : 'click';
+
         DG.DomEvent
-            .on(container, 'click', this._toggleControl, this)
+            .on(container, clickEvent, this._toggleControl, this)
             .on(container, 'dblclick', DG.DomEvent.stopPropagation)
             .on(link, 'mousedown', DG.DomEvent.stopPropagation);
 
@@ -39,8 +41,9 @@ DG.RoundControl = DG.Control.extend({
     },
 
     onRemove: function () {
+        var clickEvent = DG.Browser.touch ? 'click touchend' : 'click';
         this.fireEvent('remove');
-        DG.DomEvent.off(this._link, 'click', this._toggleControl);
+        DG.DomEvent.off(this._link, clickEvent, this._toggleControl);
     },
 
     setState: function (state) {

--- a/src/DGRoundControl/src/DGRoundControl.js
+++ b/src/DGRoundControl/src/DGRoundControl.js
@@ -28,6 +28,7 @@ DG.RoundControl = DG.Control.extend({
 
         this._map = map;
 
+        // add touchend event because tap don't work on controls when popup is open
         var clickEvent = DG.Browser.touch ? 'click touchend' : 'click';
 
         DG.DomEvent


### PR DESCRIPTION
Сейчас по тапу на карте при открытом балуне открывается новый балун (закрывая ранее открытый), а должен балун только закрыться (не открывая новый).
Т.е имеет место несколько ситуаций в зависимости от того открыт ли сейчас балун.
Если открыт, то тап в любое место карты только закрывает текущий.
Если закрыт, то тап в любое место карты открывает балун.