### PR TITLE
При вызове у маркера setPopupContent обновлять размер каллаута

### DIFF
--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -451,6 +451,8 @@
                 result = true;
             }
 
+            wrapperStyle.width = '';
+
             style.whiteSpace = 'nowrap';
             width = wrapper.offsetWidth;
             style.whiteSpace = '';


### PR DESCRIPTION
Создаем карту и маркер:

    var map;
    var marker;
    DG.then(function () {
        map = DG.map('map', {
            "center": [54.98, 82.89],
            "zoom": 13
        });
        marker = DG.marker([54.98, 82.89]).addTo(map).bindPopup('Hi').openPopup();
    });

Кликаем в маркер, появляется каллаут.
Вызываем функцию:

    function changeContent(){
        marker.setPopupContent('А теперь длинный текст');
    }

Размер каллаута должен обновиться после обновления содержимого.