### PR TITLE
Указатель мыши при драге

### DIFF
--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -82,7 +82,7 @@ DG.Poi = DG.Handler.extend({
         },
 
         mouseout: function () {
-            this._setCursor('auto');
+            this._setCursor('');
             this._map.removeLayer(this._labelHelper);
         },
 

--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -174,7 +174,7 @@ DG.Traffic = DG.TileLayer.extend({
             }
         },
         mouseout: function () {
-            this._setCursor('auto');
+            this._setCursor('');
             if (this._labelHelper) {
                 this._map.removeLayer(this._labelHelper);
             }


### PR DESCRIPTION
В хроме при драге указатель мыши отображается пальцем. Если ткнуть в пои а потом подрагать то указатель не меняется.
В ff он не меняется.
В IE 11 та же история только при драге до тыка в пои указатель 4 стрелки
UPD: достатчно навести на пои до появления тултипа