### PR TITLE
Текст в колаутах памятников в FF

### DIFF
--- a/src/DGCustomization/skin/basic/less/leaflet.less
+++ b/src/DGCustomization/skin/basic/less/leaflet.less
@@ -51,13 +51,6 @@
         line-height: 1.4;
         }
 
-.leaflet-popup {
-    transform: translate3d(0,0,0);
-    transform-style: preserve-3d;
-    perspective: 1000;
-    backface-visibility: hidden;
-    }
-
 .leaflet-popup a {
     outline: none;
     }


### PR DESCRIPTION
При скороллинге текста в колаутах памятников в FF(v34.0)  текст растягивается
Проще показать:
![menu_002](https://cloud.githubusercontent.com/assets/9331669/5466977/be7ca65c-85d8-11e4-95e6-6a1a668a8391.png)
