### PR TITLE
Кнопка закрыть в балунах съезжает на текст

### DIFF
--- a/src/DGCustomization/skin/basic/less/dg-popup.less
+++ b/src/DGCustomization/skin/basic/less/dg-popup.less
@@ -3,6 +3,10 @@
     .dg-popup__container {
         overflow: hidden;
         margin: 0;
+
+        &_withoutLayouts {
+            padding: 10px 0;
+            }
         }
 
     .leaflet-popup-scrolled .dg-popup__container { /* @TODO: .leaflet-popup-scrolled → dg-popup_scrolled_true */

--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -378,8 +378,12 @@
         },
 
         _initBodyContainer: function () {
+            var bodyClassName = (this._headerContent || this._footerContent) ?
+                'dg-popup__container' :
+                'dg-popup__container dg-popup__container_withoutLayouts';
+
             this._popupStructure.wrapper = DG.DomUtil.create('div', 'dg-popup__container-wrapper', this._contentNode);
-            this._popupStructure.body = DG.DomUtil.create('div', 'dg-popup__container', this._popupStructure.wrapper);
+            this._popupStructure.body = DG.DomUtil.create('div', bodyClassName, this._popupStructure.wrapper);
         },
 
         update: function () {


### PR DESCRIPTION
В балунах кнопка закрыть иногда наезжает на текст.
Использовалась страница с докой http://api.2gis.ru/doc/maps/examples/popups/
Немного скриншотов:
IE 11, а также IE11 в режиме совместимости с 10 и 9 (Windows 7)
![cross_ie11](https://cloud.githubusercontent.com/assets/9331669/5431780/5729f730-8451-11e4-9ff3-907362022191.png)
Opera 12.16 (Windows 7)
![cross_opera12](https://cloud.githubusercontent.com/assets/9331669/5431794/001fba50-8452-11e4-91fc-60c20029070f.png)
Opera 25 (Windows 7)
![cross_opera25](https://cloud.githubusercontent.com/assets/9331669/5431939/5d8e2562-8454-11e4-95dd-21b87f2e66c5.png)
IE 8 (Windows xp)
![cross_ie8](https://cloud.githubusercontent.com/assets/9331669/5431940/739cb5d0-8454-11e4-8fd0-bc0d2d6dfdb7.PNG)
Chrome 39 (Windows 7)
![ross_chrome39 0 2171 71 m_windows](https://cloud.githubusercontent.com/assets/9331669/5431949/af218dce-8454-11e4-8402-6961d1732bc4.png)
Firefox 34 (Windows 7)
![ross_firefox34 0 5_windows](https://cloud.githubusercontent.com/assets/9331669/5431956/cab98da2-8454-11e4-82a6-85b72ca208f2.png)
Chrome 39.0.2171.95 (Ubuntu 14.04)
![selection_044](https://cloud.githubusercontent.com/assets/9331669/5431991/c16f587a-8455-11e4-8e9d-7b0f13bdd14a.png)
![selection_045](https://cloud.githubusercontent.com/assets/9331669/5431993/c1749010-8455-11e4-890b-9d0cb0b5e078.png)
![selection_046](https://cloud.githubusercontent.com/assets/9331669/5431992/c1747a08-8455-11e4-823b-3e7fb3211fb2.png)
Firefox 34.0 (Ubuntu 14.04)
![selection_047](https://cloud.githubusercontent.com/assets/9331669/5432003/f7a15826-8455-11e4-98f6-f657cbb1eaea.png)
![selection_048](https://cloud.githubusercontent.com/assets/9331669/5432004/f7a14ff2-8455-11e4-9ec2-bcc696deb190.png)
![selection_049](https://cloud.githubusercontent.com/assets/9331669/5432002/f7a0183a-8455-11e4-8a09-85d3277bf6c6.png)

