### PR TITLE
Версии gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "4.1.0",
     "extend": "1.2.1",
     "glob": "3.2.9",
-    "gulp": "3.8.6",
+    "gulp": "^3.8.6",
     "gulp-autoprefixer": "0.0.7",
     "gulp-base64": "0.0.3",
     "gulp-bump": "0.1.4",


### PR DESCRIPTION
Немного подбешивает при сборке надпись
```
[11:53:05] Warning: gulp version mismatch:
[11:53:05] Global gulp is 3.8.10
[11:53:05] Local gulp is 3.8.6
````
Может в `package.json` поменять `"gulp": "3.8.6",` на `"gulp": "^3.8.6"`