### PR TITLE
Колауты с одним отзывом на IPAD

### DIFF
--- a/src/DGGeoclicker/skin/basic/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-popup.less
@@ -95,6 +95,7 @@
             display: inline-block;
             margin-left: 2.6em;
             vertical-align: middle;
+            white-space: nowrap;
 
             &:first-child {
                 margin-left: 1.2em;


### PR DESCRIPTION
При открытие фирм с одним отзывом на IPAD (mini и 4) в браузере (chrome и safari) наблюдается такая картинка:
![image](https://cloud.githubusercontent.com/assets/9331669/5772796/428d7062-9d7a-11e4-8e72-5b346573e3fe.jpg)
Отзыв в 2 строки