### PR TITLE
Add code coverage to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ config.local.json
 
 nohup.out
 vendors/leaflet/dist/leaflet-src.js
+
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ install:
 
 script:
   - gulp test
+
+after_success: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/build/config.js
+++ b/build/config.js
@@ -20,6 +20,11 @@ var config = {
         path: basePath + '/src/'
     },
 
+    testSource: {
+        deps: require(basePath + '/build/deps.js'),
+        path: basePath + '/build/tmp/testJS/src/'
+    },
+
     leaflet: {
         deps: require(basePath + '/vendors/leaflet/build/deps.js').deps,
         path: basePath + '/vendors/leaflet/src/'

--- a/gulp/tasks/buildTest.js
+++ b/gulp/tasks/buildTest.js
@@ -4,7 +4,7 @@ var buildEnd = require('../util/buildEnd.js');
 
 gulp.task('buildTest', [
     'buildClean',
-    'buildScripts',
+    'buildTestScripts',
     'buildTestStyles',
     'doc',
     'copyPrivateAssets'

--- a/gulp/tasks/buildTestScripts.js
+++ b/gulp/tasks/buildTestScripts.js
@@ -1,0 +1,23 @@
+var redust = require('gulp-redust');
+var file = require('gulp-file');
+var map = require('map-stream');
+var frep = require('gulp-frep');
+var gulp = require('gulp');
+
+var config = require('../../build/config.js');
+var deps = require('../../build/gulp-deps')(config);
+var projectList = require('../util/projectList');
+var error = require('../util/error');
+var stat = require('../util/stat');
+
+gulp.task('buildTestScripts', ['buildClean', 'loadProjectList', 'lint', 'buildLeaflet'], function () {
+    // part from buildJS
+    return gulp.src(deps.getJSFiles(), {base: '.'})
+        .pipe(error.handle())
+        .pipe(file('projectList.js', projectList.get()))
+        .pipe(redust(config.tmpl))
+        .pipe(frep(config.cfgParams({ssl: false})))
+        // part from buildScripts task
+        .pipe(map(stat.save))
+        .pipe(gulp.dest('build/tmp/testJS'));
+});

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -5,20 +5,22 @@ var gulp = require('gulp');
 
 var error = require('../util/error');
 var test = require('../../test/test');
+var config = require('../../build/config.js');
+var deps = require('../../build/gulp-deps')(config);
 
 var isTestDebug = util.env.d || util.env.debug;
-var testRequirements = (isTestDebug) ? [] : ['buildTest'];
+var testRequirements = isTestDebug ? [] : ['buildTest'];
 
 gulp.task('test', testRequirements, function () {
     var cliOptions = extend({}, util.env);
     var modulesToTest = [];
-    var sourcesList = [
-        'vendors/leaflet/spec/before.js',
-        'public/js/script.js',
+
+    var sourcesList = deps.getJSFiles({source: 'testSource'}).concat([
+        'build/tmp/testJS/projectList.js',
         'vendors/leaflet/spec/after.js',
         'node_modules/happen/happen.js',
         'test/geolocate.js'
-    ];
+    ]);
 
     if ('m' in cliOptions) {
         modulesToTest = cliOptions.m.split(',');
@@ -46,7 +48,10 @@ gulp.task('test', testRequirements, function () {
             browsers: test.getBrowsers(),
             reporters: test.getReporters(isTestDebug),
             junitReporter: test.getJunitReporter(),
-            action: 'run'
+            action: 'run',
+            preprocessors: {
+                'build/tmp/testJS/src/**/*.js': ['coverage']
+            }
         }))
         .on('error', function (err) {
             // Make sure failed tests cause gulp to exit non-zero

--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "underscore.string": "2.3.3"
   },
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "karma": "0.12.14",
     "karma-chrome-launcher": "0.1.2",
+    "karma-coverage": "^0.2.7",
     "karma-expect": "1.1.0",
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-bump": "0.1.4",
     "gulp-cache": "0.2.0",
     "gulp-concat": "^2.2.0",
+    "gulp-file": "^0.2.0",
     "gulp-flatten": "0.0.2",
     "gulp-footer": "1.0.5",
     "gulp-frep": "0.1.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
         // use dots reporter, as travis terminal does not support escaping sequences
         // possible values: 'dots', 'progress', 'junit', 'teamcity'
         // CLI --reporters progress
-        reporters: ['dots'],
+        reporters: ['dots', 'coverage'],
 
         // excluded, because L.DG.TileLayer added to the map by default,
         // but leaflet tests think that map without layers and fails
@@ -21,6 +21,16 @@ module.exports = function(config) {
             'vendors/leaflet/spec/suites/map/MapSpec.js',
             'vendors/leaflet/spec/suites/layer/tile/TileLayerSpec.js'
         ],
+
+        preprocessors: {
+            'public/js/script.js': ['coverage']
+        },
+
+        coverageReporter: {
+            type : 'lcov',
+            dir : 'coverage/',
+            subdir: '.'
+        },
 
         // web server port
         // CLI --port 9876
@@ -75,7 +85,8 @@ module.exports = function(config) {
             'karma-chrome-launcher',
             'karma-opera-launcher',
             'karma-firefox-launcher',
-            'karma-mocha-reporter'
+            'karma-mocha-reporter',
+            'karma-coverage'
         ]
     });
 };

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,10 +22,6 @@ module.exports = function(config) {
             'vendors/leaflet/spec/suites/layer/tile/TileLayerSpec.js'
         ],
 
-        preprocessors: {
-            'public/js/script.js': ['coverage']
-        },
-
         coverageReporter: {
             type : 'lcov',
             dir : 'coverage/',

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,8 @@ exports.getBrowsers = function () {
 exports.getReporters = function (isDebug) {
     var reporters = isDebug ? ['mocha'] : ['dots'];
 
+    reporters.push('coverage');
+
     if (argv.hasOwnProperty('reporters')) {
         reporters = argv.reporters.split(',');
     }


### PR DESCRIPTION
Надо прикрутить istanbul к проекту, чтобы он генерировал отчеты по code coverage.
Ни напрямую, ни с karma-cover пока не вышло, надо разбираться. Возможно сложности из-за того, что тесты крутятся в браузере (phantomjs в нашем случае).
Отчеты подхватит coveralls, там все настроено.