### PR TITLE
fix controls in light skin

### DIFF
--- a/src/DGCustomization/skin/basic/less/dg-zoom.less
+++ b/src/DGCustomization/skin/basic/less/dg-zoom.less
@@ -1,3 +1,4 @@
+
 .dg-zoom {
     width: 40px;
     height: 74px;
@@ -12,13 +13,18 @@
         left: 0;
 
         .leaflet-touch &:before {
-            bottom: -5px;
+            position: absolute;
+            top: -5px;
+            right: -10px;
+            bottom: 0;
+            left: -10px;
+            content: '';
             }
 
         &:after {
             position: absolute;
-            top: 34px;
             right: 0;
+            bottom: -1px;
             left: 0;
             z-index: -1;
             margin: auto;
@@ -28,6 +34,49 @@
             content: '';
             }
         }
+        .dg-zoom__button_type_in {
+            &:before,
+            .leaflet-touch &:before,
+            &:after {
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                margin: auto;
+                width: 14px;
+                height: 2px;
+                background-color: #7a7a7a; // 48%
+                box-shadow: 0 1px #fff;
+                content: '';
+                }
+
+            &:after {
+                width: 2px;
+                height: 14px;
+                }
+
+            .no-touch &:hover:before,
+            .no-touch &:hover:after {
+                background-color: #616161; // 38%
+                }
+
+            &:active:before,
+            &:active:after,
+            .no-touch &:active:before,
+            .no-touch &:active:after {
+                background-color: #575757; // 34%
+                }
+
+            .leaflet-disabled &:before,
+            .leaflet-disabled &:after,
+            .no-touch .leaflet-disabled &:hover:before,
+            .no-touch .leaflet-disabled &:hover:after,
+            .leaflet-disabled &:active:before,
+            .leaflet-disabled &:active:after {
+                box-shadow: none;
+                }
+            }
 
     .dg-zoom__out {
         position: absolute;
@@ -37,68 +86,27 @@
         margin: auto;
         width: 22px;
         height: 22px;
-        box-shadow: 0 2px 3px 0 rgba(0,0,0,.3); // override .dg-control-round
 
-        .leaflet-touch &:before {
-            top: -5px;
-            left: -19px;
-            right: -19px;
-            bottom: -19px;
+        &:after {
+            position: absolute;
+            top: -1px;
+            right: 0;
+            left: 0;
+            margin: auto;
+            width: 12px;
+            height: 2px;
+            content: '';
             }
         }
-        .dg-zoom__button_type_in {
-            &:before,
-            &:after {
-                background: #7a7a7a; // 48%
-                box-shadow: 0 1px #fff;
-                }
-
-            &:before {
-                width: 14px;
-                height: 2px;
-                }
-
-            &:after {
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                margin: auto;
-                width: 2px;
-                height: 14px;
-                content: '';
-                }
-
-            .no-touch &:hover:before,
-            .no-touch &:hover:after {
-                background: #616161; // 38%
-                }
-
-            &:active:before,
-            &:active:after,
-            .no-touch &:active:before,
-            .no-touch &:active:after {
-                background: #575757; // 34%
-                }
-
-            .leaflet-disabled &:before,
-            .leaflet-disabled &:after,
-            .no-touch .leaflet-disabled &:hover:before,
-            .no-touch .leaflet-disabled &:hover:after,
-            .leaflet-disabled &:active:before,
-            .leaflet-disabled &:active:after {
-                background: #999; // 60%
-                box-shadow: none;
-                }
-            }
-
         .dg-zoom__button_type_out {
-            &:before {
-                top: -6px;
-                bottom: auto;
-                width: 12px;
-                height: 2px;
+            width: 22px;
+            height: 22px;
+
+            .leaflet-touch &:before {
+                top: -5px;
+                right: -19px;
+                left: -19px;
+                bottom: -19px;
                 }
 
             &:after {
@@ -127,7 +135,6 @@
             .leaflet-disabled &:after,
             .no-touch .leaflet-disabled &:hover:after,
             .leaflet-disabled &:active:after {
-                background: #999; // 60%
                 box-shadow: none;
                 }
             }

--- a/src/DGCustomization/skin/dark/less/dg-zoom.less
+++ b/src/DGCustomization/skin/dark/less/dg-zoom.less
@@ -1,12 +1,9 @@
-.dg-zoom__in {
-    &:before {
-        bottom: -5px;
-        }
-    }
 
 .dg-zoom__out {
-    &:before {
-        top: -5px;
+    box-shadow: 0 2px 3px 0 rgba(0,0,0,.3);
+
+    &:after {
+        background-color: #3d3d3d; // 24%
         }
     }
 
@@ -17,20 +14,14 @@
     .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
-        background: #707070; // 44%
-        box-shadow: none;
+        background-color: #707070; // 44%
         }
     }
 
 .dg-zoom__button_type_out {
-    &:before {
-        background: #3d3d3d; // 24%
-        }
-
     .leaflet-disabled &:after,
     .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
-        background: #707070; // 44%
-        box-shadow: none;
+        background-color: #707070; // 44%
         }
     }

--- a/src/DGCustomization/skin/light/less/dg-zoom.less
+++ b/src/DGCustomization/skin/light/less/dg-zoom.less
@@ -1,7 +1,31 @@
-.dg-zoom__button_type_out {
-    &:before {
+
+.dg-zoom__out {
+    box-shadow:
+        0 0 0 1px #fff,
+        0 2px 3px 0 rgba(0,0,0,.3);
+
+    &:after {
         border: solid #fff;
         border-width: 0 1px;
-        background: #f0f0f0; // 94%
+        background-color: #f0f0f0; // 94%
+        }
+    }
+
+.dg-zoom__button_type_in {
+    .leaflet-disabled &:before,
+    .leaflet-disabled &:after,
+    .no-touch .leaflet-disabled &:hover:before,
+    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:active:before,
+    .leaflet-disabled &:active:after {
+        background-color: #999; // 60%
+        }
+    }
+
+.dg-zoom__button_type_out {
+    .leaflet-disabled &:after,
+    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:active:after {
+        background-color: #999; // 60%
         }
     }

--- a/src/DGFullScreen/skin/basic/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/basic/less/dg-control-round.less
@@ -1,7 +1,17 @@
 .dg-control-round__icon_name_fullscreen {
-    .dg-control-round__icon_state_active&:before,
-    .no-touch .dg-control-round__icon_state_active&:hover:before,
-    .dg-control-round__icon_state_active&:active:before {
+	&:after {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		margin: auto;
+		content: '';
+		}
+
+    .dg-control-round__icon_state_active&:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconEnabled');
         }
     }

--- a/src/DGFullScreen/skin/dark/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/dark/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_dark');
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_dark');
         }
     }

--- a/src/DGFullScreen/skin/light/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/light/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_light');
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_light');
         }
     }

--- a/src/DGGeoclicker/src/Controller.js
+++ b/src/DGGeoclicker/src/Controller.js
@@ -75,8 +75,6 @@ DG.Geoclicker.Controller = DG.Class.extend({
     handleResponse: function (result) { // (Object)
         var type;
 
-        this._view.hideLoader();
-
         if (!result) {
             this._runHandler('default');
             return;

--- a/src/DGGeoclicker/src/View.js
+++ b/src/DGGeoclicker/src/View.js
@@ -16,18 +16,6 @@ DG.Geoclicker.View = DG.Class.extend({
         }
     },
 
-    showLoader: function (loader) {
-        if (loader) {
-            loader.style.display = 'block';
-        }
-    },
-
-    hideLoader: function (loader) {
-        if (loader) {
-            loader.style.display = 'none';
-        }
-    },
-
     initLoader: function (isSmall) {
         var loader = document.createElement('div');
         loader.innerHTML = this._templates('loader',

--- a/src/DGGeoclicker/src/handler/House.js
+++ b/src/DGGeoclicker/src/handler/House.js
@@ -132,7 +132,8 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
             }),
             afterRender: function () {
                 self._initPopupClose();
-                if (self._firmListLoader) {
+
+                if (self._totalPages > 1 && self._firmListLoader) {
                     // "this" here is self._firmListObject
                     this.tmpl.parentNode.appendChild(self._firmListLoader);
                 }
@@ -206,14 +207,6 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
         if (!this._isFirmlistOpen) {
             this._popup.resize();
             this._isFirmlistOpen = true;
-        }
-
-        if (this._totalPages === 1) {
-            var loader = this._firmListLoader;
-
-            if (loader && loader.parentNode) {
-                loader.parentNode.removeChild(loader);
-            }
         }
     },
 

--- a/src/DGGeoclicker/src/handler/House.js
+++ b/src/DGGeoclicker/src/handler/House.js
@@ -133,7 +133,9 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
             afterRender: function () {
                 self._initPopupClose();
                 if (self._firmListLoader) {
-                    this.tmpl.parentNode.appendChild(self._firmListLoader);  // "this" here is self._firmListObject
+                    // "this" here is self._firmListObject
+                    var parent = this.tmpl.parentNode;
+                    parent.insertBefore(self._firmListLoader, parent.firstChild);
                 }
             }
         };
@@ -169,7 +171,7 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
         var loaderWrapper  = DG.DomUtil.create('div', 'dg-map-geoclicker__preloader-wrapper'),
             loader = this._view.initLoader();
 
-        loaderWrapper.appendChild(loader);
+        loaderWrapper.insertBefore(loader, loaderWrapper.firstChild);
         loaderWrapper.style.height = this._popup._contentNode.offsetHeight - 1 + 'px'; // MAGIC
         loaderWrapper.style.width = this._popup._contentNode.offsetWidth + 'px';
         this._clearAndRenderPopup({tmpl: loaderWrapper});

--- a/src/DGGeoclicker/src/handler/House.js
+++ b/src/DGGeoclicker/src/handler/House.js
@@ -211,7 +211,7 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
         if (this._totalPages === 1) {
             var loader = this._firmListLoader;
 
-            if (loader) {
+            if (loader && loader.parentNode) {
                 loader.parentNode.removeChild(loader);
             }
         }
@@ -274,7 +274,7 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
         if (this._page === this._totalPages) {
             var loader = this._firmListLoader;
 
-            if (loader) {
+            if (loader && loader.parentNode) {
                 loader.parentNode.removeChild(loader);
             }
 

--- a/src/DGGeoclicker/src/handler/House.js
+++ b/src/DGGeoclicker/src/handler/House.js
@@ -134,8 +134,7 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
                 self._initPopupClose();
                 if (self._firmListLoader) {
                     // "this" here is self._firmListObject
-                    var parent = this.tmpl.parentNode;
-                    parent.insertBefore(self._firmListLoader, parent.firstChild);
+                    this.tmpl.parentNode.appendChild(self._firmListLoader);
                 }
             }
         };
@@ -209,8 +208,12 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
             this._isFirmlistOpen = true;
         }
 
-        if (this._totalPages === 1 && this._firmListLoader) {
-            this._view.hideLoader(this._firmListLoader);
+        if (this._totalPages === 1) {
+            var loader = this._firmListLoader;
+
+            if (loader) {
+                loader.parentNode.removeChild(loader);
+            }
         }
     },
 
@@ -269,9 +272,12 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
         }
 
         if (this._page === this._totalPages) {
-            if (this._firmListLoader) {
-                this._view.hideLoader(this._firmListLoader);
+            var loader = this._firmListLoader;
+
+            if (loader) {
+                loader.parentNode.removeChild(loader);
             }
+
             this._popup.off('scroll', this._onScroll);
         }
     }

--- a/src/DGLocation/skin/basic/less/dg-control-round.less
+++ b/src/DGLocation/skin/basic/less/dg-control-round.less
@@ -1,7 +1,18 @@
+
 .dg-control-round__icon_name_locate {
-    .dg-control-round__icon_state_active&:before,
-    .no-touch .dg-control-round__icon_state_active&:hover:before,
-    .dg-control-round__icon_state_active&:active:before {
+    &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        content: '';
+        }
+
+    .dg-control-round__icon_state_active&:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__locateIconEnabled');
         }
     }

--- a/src/DGLocation/skin/dark/less/dg-control-round.less
+++ b/src/DGLocation/skin/dark/less/dg-control-round.less
@@ -1,16 +1,16 @@
 .dg-control-round__icon_name_locate {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_dark');
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_dark');
         }
 
-    .dg-control-round__icon_state_requesting&:before,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:before,
-    .dg-control-round__icon_state_requesting&:active:before {
+    .dg-control-round__icon_state_requesting&:after,
+    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_dark');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;

--- a/src/DGLocation/skin/light/less/dg-control-round.less
+++ b/src/DGLocation/skin/light/less/dg-control-round.less
@@ -1,16 +1,16 @@
 .dg-control-round__icon_name_locate {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_light');
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_light');
         }
 
-    .dg-control-round__icon_state_requesting&:before,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:before,
-    .dg-control-round__icon_state_requesting&:active:before {
+    .dg-control-round__icon_state_requesting&:after,
+    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_light');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;

--- a/src/DGRoundControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/basic/less/dg-control-round.less
@@ -1,51 +1,27 @@
+
 .dg-control-round {
     position: relative;
+    padding: 5px;
     width: 30px;
     height: 30px;
     border-radius: 50%;
     cursor: default;
-
-    .leaflet-touch &:before {
-        position: absolute;
-        top: -10px;
-        right: -15px;
-        bottom: -10px;
-        left: -15px;
-        content: '';
-        }
-
-    .leaflet-touch.debug &:before {
-        background-color: red;
-        opacity: .5;
-        }
     }
     .dg-control-round__icon {
-        position: absolute;
-        width: 100%;
-        height: 100%;
+        position: relative;
+        display: block;
+        width: 30px;
+        height: 30px;
         border-radius: 50%;
         background-color: #f0f0f0; // 94%, fallback
         background-image: linear-gradient(to bottom, #fff 0, hsl(0,0%,88%) 100%);
         color: #2b2a29;
         text-align: center;
+        text-decoration: none;
         text-shadow: 0 1px 0 #fff;
-        font-size: 30px;
+        font-size: 22px;
         line-height: 30px;
         cursor: pointer;
-
-        &:before {
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            margin: auto;
-            width: 18px;
-            height: 18px;
-            background-size: contain;
-            background-repeat: no-repeat;
-            content: '';
-            }
 
         .no-touch &:hover {
             background-color: #f5f5f5; // 96%, fallback
@@ -62,9 +38,17 @@
         .leaflet-disabled &,
         .no-touch .leaflet-disabled &:hover,
         .leaflet-disabled &:active {
-            background-color: #e0e0e0; // 88%
             background-image: none;
             cursor: default;
+            }
+
+        .leaflet-touch &:before {
+            position: absolute;
+            top: -10px;
+            right: -15px;
+            bottom: -10px;
+            left: -15px;
+            content: '';
             }
         }
 

--- a/src/DGRoundControl/skin/dark/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/dark/less/dg-control-round.less
@@ -1,5 +1,6 @@
+
 .dg-control-round {
-    border: 5px solid #3d3d3d; // 24%
+    background-color: #3d3d3d; // 24%
     box-shadow: 0 3px 5px 0 rgba(0,0,0,.3);
     }
     .dg-control-round__icon {

--- a/src/DGRoundControl/skin/light/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/light/less/dg-control-round.less
@@ -1,20 +1,18 @@
-.dg-control-round {
-    border: 5px solid #f0f0f0; // 94%
-    box-shadow: 0 2px 5px 0 rgba(0,0,0,.3);
 
-    &:before {
-        position: absolute;
-        margin: -6px 0 0 -6px;
-        padding: 5px;
-        width: 100%;
-        height: 100%;
-        border: 1px solid #fff;
-        border-radius: 50%;
-        content: '';
-        }
+.dg-control-round {
+    background-color: #f0f0f0; // 94%
+    box-shadow:
+        0 0 0 1px #fff,
+        0 2px 5px 0 rgba(0,0,0,.3);
     }
     .dg-control-round__icon {
         box-shadow: 0 0 1px 0 rgba(0,0,0,.4);
+
+        .leaflet-disabled &,
+        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:active {
+            background-color: #e0e0e0; // 88%
+            }
 
         .leaflet-disabled & {
             box-shadow: none;

--- a/src/DGRulerControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRulerControl/skin/basic/less/dg-control-round.less
@@ -1,17 +1,24 @@
 
 .dg-control-round__icon_name_ruler {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__rulerIcon');
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        content: '';
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconHover');
         }
 
-    .dg-control-round__icon_state_active&:before,
-    .no-touch .dg-control-round__icon_state_active&:hover:before,
-    .dg-control-round__icon_state_active&:active:before {
+    .dg-control-round__icon_state_active&:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconEnabled');
         }
     }

--- a/src/DGTrafficControl/skin/basic/less/dg-control-round.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-control-round.less
@@ -1,17 +1,24 @@
 
 .dg-control-round__icon_name_traffic {
-    &:before {
+    &:after {
         .notRepeatableBgWithSizes('DGRoundControl__trafficIcon');
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        content: '';
         }
 
-    .no-touch &:hover:before,
-    &:active:before {
+    .no-touch &:hover:after,
+    &:active:after {
         .notRepeatableBg('DGRoundControl__trafficIconHover');
         }
 
-    .dg-control-round__icon_state_active&:before,
-    .no-touch .dg-control-round__icon_state_active&:hover:before,
-    .dg-control-round__icon_state_active&:active:before {
+    .dg-control-round__icon_state_active&:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:active:after {
         background-image: none;
         }
     }

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
@@ -6,9 +6,9 @@
     text-shadow: 0 1px 2px rgba(0,0,0,.3);
     font: normal 15px/32px 'Arial narrow', Arial, sans-serif;
 
-    &_color_green:before,
-    &_color_yellow:before,
-    &_color_red:before {
+    &_color_green:after,
+    &_color_yellow:after,
+    &_color_red:after {
         position: absolute;
         top: 0;
         right: 0;
@@ -24,27 +24,30 @@
             0 1px 0 0 #fff;
         }
 
-    &_color_green:before {
+    &_color_green:after {
         background: #3fc03b;
         }
 
-    &_color_green:hover:before {
+    .no-touch &_color_green:hover:after,
+    &_color_green:active:after {
         background: linear-gradient(to top, #2aa731, #53e13a) #3ec435;
         }
 
-    &_color_yellow:before {
+    &_color_yellow:after {
         background: #f3b223;
         }
 
-    &_color_yellow:hover:before {
+    .no-touch &_color_yellow:hover:after,
+    &_color_yellow:active:after {
         background: linear-gradient(to top, #ef931b, #f7be26) #f4a820;
         }
 
-    &_color_red:before {
+    &_color_red:after {
         background: #eb240c;
         }
 
-    &_color_red:hover:before {
+    .no-touch &_color_red:hover:after,
+    &_color_red:active:after {
         background: linear-gradient(to top, #c01c0a, #f73416) #db2811;
         }
     }


### PR DESCRIPTION
Перефигачил контролы в светлой теме, там не хватало одного after-а на каждой кнопке, через который делались прозрачные плашки для нормального попадания по кнопкам в мобилках. Афтер был занят элементом, бордер которого рисовал бордер для контролов. Бордер у самого контрола нельзя сделать по причине которую я сегодня уже не помню, но когда я начал так делать, наткнулся на неё и пришлось откатывать всё. В результате сделал тенью, т. е. сейчас бордер нарисован белой тенью.