### PR TITLE
После линейки не кликабельны POI

### DIFF
--- a/src/DGGeoclicker/src/DGGeoclicker.js
+++ b/src/DGGeoclicker/src/DGGeoclicker.js
@@ -23,7 +23,7 @@ DG.Geoclicker = DG.Handler.extend({
     _toggleEvents: function (flag) {
         this._map[flag ? 'on' : 'off'](this._mapEventsListeners, this);
         if (this._map.poi) {
-            this._map.poi.getMetaLayer()[flag ? 'on' : 'off']('click', DG.bind(this._mapEventsListeners.click, this));
+            this._map.poi.getMetaLayer()[flag ? 'on' : 'off']('click', this._mapEventsListeners.click, this);
         }
     },
 


### PR DESCRIPTION
Баг в мастере
ПВ:
1. Кликаем по контролу линейки
2. Кликаем по контролу линейки
3. Кликаем в POI
4. Кликаем по контролу линейки
5. Кликаем по контролу линейки
6. Кликаем в POI
ОР: Видим POI на 3 и 6 шаге
ФР:  Видим POI на 6 шаге

