### PR TITLE
Вытаскивать балуны из-под контролов

### DIFF
--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -519,6 +519,9 @@
 }());
 
 
+L.Popup.prototype.options.autoPanPadding = [60, 5];
+
+
 DG.Map.include({
     _markerClass: 'dg-customization__marker_type_mushroom',
     _markerShowClass: 'dg-customization__marker_appear',

--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -39,8 +39,11 @@
     DG.Popup.prototype.options.offset = DG.point(offsetX, offsetY);
 
     DG.Popup.mergeOptions({
-        border: 16
+        border: 16,
+        controlsWidth: 60
     });
+
+    var origAutoPanPadding0 = DG.Popup.prototype.options.autoPanPadding[0];
 
     DG.Popup.include({
         _headerContent: null,
@@ -67,7 +70,12 @@
         onAdd: function (map) { // (Map)
             map.on('entranceshow', this._closePopup, this);
 
-            this.options.autoPanPadding[0] = this._map._container.offsetWidth >= this.options.maxWidth + 120 ? 60 : 5;
+            var opts = this.options;
+
+            DG.Popup.prototype.options.autoPanPadding[0] =
+                this._map._container.offsetWidth >= opts.maxWidth + (opts.controlsWidth * 2) ?
+                    opts.controlsWidth :
+                    origAutoPanPadding0;
 
             originalOnAdd.call(this, map);
             this._animateOpening();

--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -66,6 +66,9 @@
 
         onAdd: function (map) { // (Map)
             map.on('entranceshow', this._closePopup, this);
+
+            this.options.autoPanPadding[0] = this._map._container.offsetWidth >= this.options.maxWidth + 120 ? 60 : 5;
+
             originalOnAdd.call(this, map);
             this._animateOpening();
         },
@@ -517,9 +520,6 @@
 
     });
 }());
-
-
-L.Popup.prototype.options.autoPanPadding = [60, 5];
 
 
 DG.Map.include({

--- a/src/DGCustomization/src/DGPopup.js
+++ b/src/DGCustomization/src/DGPopup.js
@@ -62,8 +62,11 @@
         _popupTipClass: 'leaflet-popup-tip-container',
         _tipSVGPath: 'M0 0c12.643 0 28 7.115 28 44h2c0-36.885 15.358-44 28-44h-58z',
 
+        _isAutoPanPaddingUserDefined: false,
+
         initialize: function (options, source) { // (Object, Object)
             this._popupStructure = {};
+            this._isAutoPanPaddingUserDefined = options && options.hasOwnProperty('autoPanPadding');
             originalInitialize.call(this, options, source);
         },
 
@@ -72,10 +75,14 @@
 
             var opts = this.options;
 
-            DG.Popup.prototype.options.autoPanPadding[0] =
-                this._map._container.offsetWidth >= opts.maxWidth + (opts.controlsWidth * 2) ?
-                    opts.controlsWidth :
-                    origAutoPanPadding0;
+            if (!this._isAutoPanPaddingUserDefined) {
+                opts.autoPanPadding = [
+                    this._map._container.offsetWidth >= opts.maxWidth + (opts.controlsWidth * 2) ?
+                        opts.controlsWidth :
+                        origAutoPanPadding0,
+                    opts.autoPanPadding[1]
+                ];
+            }
 
             originalOnAdd.call(this, map);
             this._animateOpening();


### PR DESCRIPTION
Сейчас при открытии балунов автоматически двигается карта, чтобы открытый коллаут полностью уместился на экране. Однако при этом не учитываются контролы, в результате чего открытый балун может оказаться частично под кнопкой:
![99980d9e-76f2-11e4-9931-ae038d4d6ce7](https://cloud.githubusercontent.com/assets/4540062/5276395/3c5b8788-7ad9-11e4-8e9a-7b380e73b59c.png)

Это проявляется как в пользовательских коллаутах, так и в коллаутах геокликера.

В лифлете есть механизм, чтобы этим управлять: при создании коллаута можно указать паддинг в пикселях от краёв карты. Нужно подумать, как заиспользовать его у нас и для каких коллаутов.