### PR TITLE
gulp-jshint crash build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-git": "0.4.0",
     "gulp-header": "1.0.5",
     "gulp-if": "1.1.0",
-    "gulp-jshint": "1.6.4",
+    "gulp-jshint": "^1.9.2",
     "gulp-karma": "0.0.4",
     "gulp-less": "1.3.3",
     "gulp-minify-css": "0.3.2",


### PR DESCRIPTION
Судя по всему из-за этого https://github.com/spenceralger/gulp-jshint/issues/95 , ждём, когда пофиксят.