### PR TITLE
All popups have 0.9 opacity

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -194,7 +194,8 @@ var deps = {
                 'DGGeoclicker/skin/{skin}/less/dg-firm-card.less',
                 'DGGeoclicker/skin/{skin}/less/dg-schedule.less',
                 'DGGeoclicker/skin/{skin}/less/dg-link.less'
-            ]
+            ],
+            ie: ['DGGeoclicker/skin/{skin}/less/dg-popup.ie.less']
         },
         src: [
             'DGGeoclicker/src/DGGeoclicker.js',

--- a/src/DGCustomization/skin/basic/less/leaflet.less
+++ b/src/DGCustomization/skin/basic/less/leaflet.less
@@ -105,7 +105,7 @@
 
 .leaflet-map-pane .leaflet-popup-tip-container {
     position: relative;
-    margin: -1px auto 0;
+    margin: 0 auto;
     width: 58px;
     height: 47px;
     background-repeat: no-repeat;

--- a/src/DGCustomization/skin/dark/less/leaflet.ie.less
+++ b/src/DGCustomization/skin/dark/less/leaflet.ie.less
@@ -1,5 +1,8 @@
 .leaflet-popup-content-wrapper {
     .opacity(0.85);
     background-color: #323232;
-    border: 0 !important;
+    }
+
+.leaflet-oldie .leaflet-popup-content-wrapper {
+    border: 0;
     }

--- a/src/DGCustomization/skin/dark/less/leaflet.ie.less
+++ b/src/DGCustomization/skin/dark/less/leaflet.ie.less
@@ -1,3 +1,5 @@
 .leaflet-popup-content-wrapper {
     .opacity(0.85);
+    background-color: #323232;
+    border: 0 !important;
     }

--- a/src/DGCustomization/skin/dark/less/leaflet.less
+++ b/src/DGCustomization/skin/dark/less/leaflet.less
@@ -1,8 +1,5 @@
-.leaflet-popup-inner {
-    opacity: .9;
-    }
 .leaflet-popup-content-wrapper {
-    background-color: #323232;
+    background-color: rgba(50, 50, 50, 0.9);
     }
 
 .leaflet-popup-tip-container_image {
@@ -10,7 +7,7 @@
     }
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
-    fill: #323232;
+    fill: rgba(50, 50, 50, 0.9);
     }
 
 .leaflet-container a.leaflet-popup-close-button {

--- a/src/DGCustomization/skin/light/less/leaflet.ie.less
+++ b/src/DGCustomization/skin/light/less/leaflet.ie.less
@@ -1,7 +1,10 @@
 .leaflet-popup-content-wrapper {
     .opacity(0.95);
     background-color: #fff;
-    border-color: #bebdb5 !important;
+    }
+
+.leaflet-oldie .leaflet-popup-content-wrapper {
+    border-color: #bebdb5;
     }
 
 .leaflet-map-pane .leaflet-popup-tip-container {

--- a/src/DGCustomization/skin/light/less/leaflet.ie.less
+++ b/src/DGCustomization/skin/light/less/leaflet.ie.less
@@ -1,0 +1,9 @@
+.leaflet-popup-content-wrapper {
+    .opacity(0.95);
+    background-color: #fff;
+    border-color: #bebdb5 !important;
+    }
+
+.leaflet-map-pane .leaflet-popup-tip-container {
+    margin-top: -1px;
+    }

--- a/src/DGCustomization/skin/light/less/leaflet.less
+++ b/src/DGCustomization/skin/light/less/leaflet.less
@@ -1,11 +1,7 @@
-.leaflet-popup-inner {
-    opacity: .95;
-    }
-
 .leaflet-popup-content-wrapper {
     border: 1px solid #bebdb5;
     border-color: rgba(151,151,151,.6);
-    background-color: #fff;
+    background-color: rgba(255, 255, 255, 0.95);
     color: #000;
     }
 
@@ -15,7 +11,7 @@
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     margin-top: -2px;
-    fill: #fff;
+    fill: rgba(255, 255, 255, 0.95);
     stroke: #bebdb5;
     stroke-dasharray: 0,10,100,60;
     }

--- a/src/DGGeoclicker/skin/dark/less/dg-popup.ie.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-popup.ie.less
@@ -1,0 +1,3 @@
+.dg-popup__footer-button {
+    background-color: #373737;
+    }

--- a/src/DGGeoclicker/skin/dark/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-popup.less
@@ -18,7 +18,6 @@ a.dg-popup__link {
     }
 
 .dg-popup__footer-button {
-    background: #000;
     background: rgba(0,0,0,.2);
     box-shadow: 0 1px rgba(0,0,0,.1);
 


### PR DESCRIPTION
Кнопка button имеет следующий стиль:
```css
width: 250px;
height: 100px;
background: red;
```
Несмотря на это её фон всё равно прозрачный, дело в элементе `leaflet-popup-inner`, у которого стоит `opacity: 0.9;`

![screenshot from 2015-01-21 15 04 14](https://cloud.githubusercontent.com/assets/3996552/5833569/796a3f34-a176-11e4-94e5-cccfbd9fe07f.png)