### PR TITLE
Support for new WebAPI contacts format

### DIFF
--- a/src/DGGeoclicker/templates/firmCardContacts.dust
+++ b/src/DGGeoclicker/templates/firmCardContacts.dust
@@ -23,7 +23,7 @@
             {/eq}
             {@eq value="website" type="string"}
                 <div class="dg-firm-card__link dg-firm-card__site dg-firm-card__icon">
-                    <a href="{value}" target="_blank" class="dg-link_scheme_dark dg-firm-card__sitelink">{text}</a>
+                    <a href="{url}" target="_blank" class="dg-link_scheme_dark dg-firm-card__sitelink">{text}</a>
                 </div>
             {/eq}
             {@eq value="email" type="string"}

--- a/vendors/firmcard/src/FirmCard.js
+++ b/vendors/firmcard/src/FirmCard.js
@@ -40,6 +40,11 @@ FirmCard.prototype = {
             var data = res.result.items;
             if (data !== 'undefined') {
                 self._firmData = data[0];
+
+                // Support for old WebAPI format.
+                // TODO: remove this call after WebAPI release
+                self._convertWebsite();
+
                 self._firmId = firmId;
                 self._renderFirmCard();
                 self._toggleEventHandlers();
@@ -93,6 +98,22 @@ FirmCard.prototype = {
         });
 
         return result;
+    },
+
+    // Support for old WebAPI format.
+    // TODO: remove this function after WebAPI release
+    _convertWebsite: function () {
+        this._firmData.contact_groups.forEach(function (group) {
+            group.contacts.forEach(function (contact) {
+                if (contact.type != 'website') {
+                    return;
+                }
+
+                if (typeof contact.url == 'undefined') {
+                    contact.url = contact.value;
+                }
+            });
+        });
     },
 
     _renderFirmCard: function () {

--- a/vendors/firmcard/src/FirmCard.js
+++ b/vendors/firmcard/src/FirmCard.js
@@ -109,7 +109,7 @@ FirmCard.prototype = {
                     return;
                 }
 
-                if (typeof contact.url == 'undefined') {
+                if (!contact.url) {
                     contact.url = contact.value;
                 }
             });


### PR DESCRIPTION
В геокликер добавлена функция, которая приводит все контакты фирмы к новому формату (если контакт уже в новом формате, ничего не делается). После релиза WebAPI её нужно будет просто удалить.