### PR TITLE
Eliminate mouse events dead zone under callouts

### DIFF
--- a/src/DGCustomization/skin/basic/less/leaflet.less
+++ b/src/DGCustomization/skin/basic/less/leaflet.less
@@ -104,11 +104,15 @@
 .leaflet-popup_error_true {}
 
 .leaflet-map-pane .leaflet-popup-tip-container {
-    position: relative;
-    margin: 0 auto;
+    position: absolute;
+    left: 50%;
+    margin-left: -29px;
+    top: auto;
+    bottom: -47px;
     width: 58px;
     height: 47px;
     background-repeat: no-repeat;
+    pointer-events: none;
     }
     .leaflet-popup-tip {
         display: none;

--- a/src/DGCustomization/skin/basic/skin.config.js
+++ b/src/DGCustomization/skin/basic/skin.config.js
@@ -2,7 +2,7 @@ DG.configTheme = {
     balloonOptions: {
         offset: {
             x: 1,
-            y: 9
+            y: -43
         }
     },
 

--- a/src/DGCustomization/skin/light/less/leaflet.ie.less
+++ b/src/DGCustomization/skin/light/less/leaflet.ie.less
@@ -6,7 +6,3 @@
 .leaflet-oldie .leaflet-popup-content-wrapper {
     border-color: #bebdb5;
     }
-
-.leaflet-map-pane .leaflet-popup-tip-container {
-    margin-top: -1px;
-    }

--- a/src/DGCustomization/skin/light/less/leaflet.less
+++ b/src/DGCustomization/skin/light/less/leaflet.less
@@ -9,6 +9,10 @@
     .notRepeatableBg('DGCustomization__popupShadow_light', true);
     }
 
+.leaflet-map-pane .leaflet-popup-tip-container {
+    bottom: -46px;
+    }
+
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     margin-top: -2px;
     fill: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
Зона слева и справа от хвостика коллаута теперь полностью прозрачна для событий мыши. Сам хвостик также пропускает события (кроме IE8–10).

Стоит проверить внешний вид попапов в тёмной и светлой теме (IE, мобилки) и убедиться, что не сломалась привязка попапа к карте