### PR TITLE
Don't work closePopupOnClick false map option

### DIFF
--- a/src/DGGeoclicker/src/View.js
+++ b/src/DGGeoclicker/src/View.js
@@ -7,7 +7,8 @@ DG.Geoclicker.View = DG.Class.extend({
             minHeight: 50,
             maxWidth: 385,
             minWidth: 310,
-            sprawling: true
+            sprawling: true,
+            closeOnClick: true
         });
 
         /*global __DGGeoclicker_TMPL__ */


### PR DESCRIPTION
Баг в мастере
Шаги воспроизведения:
1.В демке добавляем к карте опцию
`"closePopupOnClick":false`
2. Открываем страницу с демкой
3. Кликаем мимо балуна
ОР: Балун открыт т.к по умолчанию у пользовательских балунов не задается closeOnClick,
а глобальное поведение для всех балунов задается опцией карты closePopupOnClick.
ФР: Балун закрывается.

Шаги воспроизведения:
1.В демке добавляем к карте опцию
`"closePopupOnClick":false`
2. Открываем страницу с демкой
3. Кликаем мимо балуна N раз по району, не закрывая балуны
ФР: Множество раз накладывается цветовой слой. В svg.leaflet-zoom-animated по каждому клику добавляется слой.
ОР: Отображать только последний слой.