### PR TITLE
Build images only for modules from pkg param

### DIFF
--- a/build/gulp-deps.js
+++ b/build/gulp-deps.js
@@ -126,6 +126,30 @@ var init = function (config) {
             .filter(fs.existsSync);
     }
 
+    function getImgGlob(options) {
+        options = options || {};
+
+        var source = config[options.source || 'source'];
+        var modules = source.deps;
+
+        return getModulesList(options.pkg, modules)
+            .map(function(name) {
+                return 'src/' + name + '/**/img/**/*.{png,gif,jpg,jpeg}';
+            });
+    }
+
+    function getSVGGlob(options) {
+        options = options || {};
+
+        var source = config[options.source || 'source'];
+        var modules = source.deps;
+
+        return getModulesList(options.pkg, modules)
+            .map(function(name) {
+                return 'src/' + name + '/**/img/**/*.svg';
+            });
+    }
+
     // Build string with Less variables and imports
     function lessHeader(options) {
         options = options || {};
@@ -253,7 +277,10 @@ var init = function (config) {
         getSkinsList: getSkinsList,
 
         getImagesFilesStats: getImagesFilesStats,
-        getImagesUsageStats: getImagesUsageStats
+        getImagesUsageStats: getImagesUsageStats,
+
+        getImgGlob: getImgGlob,
+        getSVGGlob: getSVGGlob
     };
 };
 

--- a/gulp/tasks/copyRaster.js
+++ b/gulp/tasks/copyRaster.js
@@ -1,15 +1,18 @@
 var flatten = require('gulp-flatten');
 var rename = require('gulp-rename');
+var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
 
 var error = require('../util/error');
+var config = require('../../build/config');
+var deps = require('../../build/gulp-deps')(config);
 
 gulp.task('copyRaster', function () {
-    return gulp.src(['src/**/img/**/*.{png,gif,jpg,jpeg}'])
+    return gulp.src(deps.getImgGlob(util.env))
         .pipe(error.handle())
         .pipe(rename(function (p) {
-            p.dirname = p.dirname.split(path.sep)[2];
+            p.dirname = p.dirname.split(path.sep)[1];
         }))
         .pipe(gulp.dest('build/tmp/img'))
         .pipe(flatten())

--- a/gulp/tasks/copySVG.js
+++ b/gulp/tasks/copySVG.js
@@ -1,15 +1,18 @@
 var flatten = require('gulp-flatten');
 var rename = require('gulp-rename');
+var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
 
 var error = require('../util/error');
+var config = require('../../build/config');
+var deps = require('../../build/gulp-deps')(config);
 
 gulp.task('copySVG', function () {
-    return gulp.src('src/**/img/**/*.svg')
+    return gulp.src(deps.getSVGGlob(util.env))
         .pipe(error.handle())
         .pipe(rename(function (p) {
-            p.dirname = p.dirname.split(path.sep)[2];
+            p.dirname = p.dirname.split(path.sep)[1];
         }))
         .pipe(gulp.dest('build/tmp/img'))
         .pipe(flatten())

--- a/gulp/tasks/rasterAndCopySVG.js
+++ b/gulp/tasks/rasterAndCopySVG.js
@@ -1,9 +1,9 @@
 var flatten = require('gulp-flatten');
 var rename = require('gulp-rename');
 var rsvg = require('gulp-rsvg');
+var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
-var util = require('util');
 
 var error = require('../util/error');
 var config = require('../../build/config');

--- a/gulp/tasks/rasterAndCopySVG.js
+++ b/gulp/tasks/rasterAndCopySVG.js
@@ -3,27 +3,30 @@ var rename = require('gulp-rename');
 var rsvg = require('gulp-rsvg');
 var gulp = require('gulp');
 var path = require('path');
+var util = require('util');
 
 var error = require('../util/error');
+var config = require('../../build/config');
+var deps = require('../../build/gulp-deps')(config);
 
 gulp.task('rasterAndCopySVG', function (cb) {
-    gulp.src('src/**/img/**/*.svg')
+    gulp.src(deps.getSVGGlob(util.env))
         .pipe(error.handle())
         .pipe(rsvg())
         .pipe(rename(function (p) {
-            p.dirname = p.dirname.split(path.sep)[2];
+            p.dirname = p.dirname.split(path.sep)[1];
         }))
         .pipe(gulp.dest('build/tmp/img'))
         .pipe(flatten())
         .pipe(gulp.dest('build/tmp/img_all'))
         .pipe(gulp.dest('public/img'))
         .on('end', function () {
-            gulp.src('src/**/img/**/*.svg')
+            gulp.src(deps.getSVGGlob(util.env))
                 .pipe(error.handle())
                 .pipe(rsvg({scale: 2}))
                 .pipe(rename(function (p) {
                     p.extname = '@2x.png';
-                    p.dirname = p.dirname.split(path.sep)[2];
+                    p.dirname = p.dirname.split(path.sep)[1];
                 }))
                 .pipe(gulp.dest('build/tmp/img'))
                 .pipe(flatten())

--- a/gulp/util/buildCSS.js
+++ b/gulp/util/buildCSS.js
@@ -9,6 +9,7 @@ var less = require('gulp-less');
 var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
+var fs = require('fs');
 
 var config = require('../../build/config.js');
 var deps = require('../../build/gulp-deps')(config);
@@ -43,6 +44,16 @@ module.exports = function (options, enableSsl) {
             './private/less/mixins.ie8.less:reference'
         ];
     }
+
+    lessHeaderImports = lessHeaderImports.filter(function(src) {
+        var lessFileSrc = src.split(':')[0];
+
+        try {
+            return fs.readFileSync(path.join(__dirname, '../..', lessFileSrc));
+        } catch (e) {
+            return false;
+        }
+    });
 
     var lessPrerequirements = deps.lessHeader({
         variables: {


### PR DESCRIPTION
We collect all images for each build.

If there is pkg param in build command we should build only images that we need in this modules.

Usage example:
```gulp build --pkg=DGTileLayer,DGWkt,DGPoi,DGEntrance,DGRuler,DGTraffic```