### PR TITLE
Return gulp-cache fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ public
 dist
 private/dev*
 build/tmp
+build/cache
 
 docbuilder/doc
 .tern-port

--- a/gulp/util/fixFileCache.js
+++ b/gulp/util/fixFileCache.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 var mkdirp = require('mkdirp');
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,11 @@
 var requireDir = require('require-dir');
+var cache = require('gulp-cache');
 
 requireDir('./gulp/tasks', { recurse: true });
+
+// fix file cache due to buggy realization
+// https://github.com/2gis/mapsapi/pull/38
+require('./gulp/util/fixFileCache')(cache.fileCache, './build/cache');
 
 module.exports = {
     getJS: require('./gulp/util/buildJS'),


### PR DESCRIPTION
В своём пулл-реквесте https://github.com/2gis/mapsapi/pull/146 случано выпилил фикс для онлайна для параллельной сборки проекта.

К сожалению, все попытки выпилить этот плагин провалились из-за нашей сборки, т.к. у нас нет отдельной релизной таски, и все js и css файлы генеряться на ходу при запросе. Соотв-но, что-то вроде `gulp-cached`, `gulp-newer` задействовать нельзя.

`gulp-cache` в основном используюется для `gulp-uglify` и `gulp-autoprefixer`, если `uglify` мы при разработке можем избежать запрашивая сборку с `mode=debug`, то обойти `autoprefixer` не получится.