### PR TITLE
Fix bug with webapi booklet

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -17,7 +17,7 @@
     "WEB_API_KEY": "rujrdp3400",
     "WEB_API_VERSION": "2.0",
     "REGION_LIST_FIELDS": "items.bounds,items.zoom_level,items.time_zone,items.code,items.flags,items.country_code,items.domain",
-    "FIRM_INFO_FIELDS": "items.reviews,items.photos,items.links,items.booklet",
+    "FIRM_INFO_FIELDS": "items.reviews,items.photos,items.links,items.external_content",
     "GEO_ADDITIONAL_FIELDS": "items.geometry.selection,items.links,items.adm_div,items.address,items.floors,items.description",
     "GEOCLICKER_CATALOG_API_KEY": "ruxlih0718",
     "DEFAULT_LANG": "ru",

--- a/vendors/firmcard/src/FirmCard.js
+++ b/vendors/firmcard/src/FirmCard.js
@@ -258,8 +258,16 @@ FirmCard.prototype = {
         var links = [],
             reviewData = this._firmData.reviews,
             photos = this._firmData.photos,
-            booklet = this._firmData.booklet,
+            booklet,
             link;
+
+        if (this._firmData.external_content) {
+            this._firmData.external_content.forEach(function(el) {
+                if (el && el.type == 'booklet') {
+                    booklet = el;
+                }
+            });
+        }
 
         if (reviewData && reviewData.is_reviewable) {
             links.push({

--- a/vendors/firmcard/src/FirmCard.js
+++ b/vendors/firmcard/src/FirmCard.js
@@ -262,7 +262,7 @@ FirmCard.prototype = {
             link;
 
         if (this._firmData.external_content) {
-            this._firmData.external_content.forEach(function(el) {
+            this._firmData.external_content.forEach(function (el) {
                 if (el && el.type == 'booklet') {
                     booklet = el;
                 }


### PR DESCRIPTION
Обнаружили такую проблему при запросе на:
http://catalog.api.2gis.ru/2.0/catalog/branch/get?key=12345678&type=filial&id=141265769369916&fields=items.reviews%2Citems.photos%2Citems.links%2Citems.booklet​

```"Param 'fields' is invalid. Value 'items.booklet' is outside of allowed values: 'items.region_id', 'items.name_ex', 'items.alias', 'items.point', 'items.adm_div', 'items.org', 'items.dates', 'items.photos', 'items.see_also', 'items.flags', 'items.external_content', 'items.locale', 'items.reviews', 'items.address.is_conditional', 'items.links'"
type: "paramIsOutsideSet"```