### PR TITLE
Not change control positions on touch devices

### DIFF
--- a/private/index.html
+++ b/private/index.html
@@ -6,27 +6,43 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script src="__LOADER_URL__" data-id="dgLoader"></script>
-    <style type="text/css">
+
+    <style>
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }
+        .leaflet-touch .leaflet-bottom .dg-attribution { margin-top: 70px; }
+        .leaflet-touch .leaflet-bottom .dg-zoom {margin: 40px 10px 40px 0; }
     </style>
 </head>
 <body>
 
 <div id="map"></div>
 
-<script type="text/javascript">
+<script>
     var map,
+        options,
         balloonHTML;
 
     DG.then(function () {
-        map = new DG.Map('map', {
-            "center": new DG.LatLng(54.980156831455, 82.897440725094),
-            "zoom": 13,
-            "geoclicker": true,
-            "worldCopyJump": true,
-            "locationControl": true
+        map = DG.map('map', {
+            center: new DG.LatLng(54.980156831455, 82.897440725094),
+            zoom: 13,
+            geoclicker: true,
+            worldCopyJum: true,
+            zoomControl: false,
+            fullscreenControl: false
         });
+
+        // change control position on touch devices
+        if (DG.Browser.touch) {
+            options = { position: 'bottomright' };
+        }
+
+        DG.control.fullscreen(options).addTo(map);
+        DG.control.traffic(options).addTo(map);
+        DG.control.zoom(options).addTo(map);
+        DG.control.location(options).addTo(map);
+        DG.control.ruler(options).addTo(map);
 
         balloonHTML = '<a href="http://www.2gis.ru/" target="_blank">\n\
         <img src="/2.0/img/2gis-logo.png" alt="2GIS" title="2GIS" width="146" height="70" style="border: none"></a>\n\
@@ -36,6 +52,5 @@
         DG.marker([54.980156831455, 82.897440725094]).addTo(map).bindPopup(balloonHTML).openPopup();
     });
 </script>
-
 </body>
 </html>

--- a/private/index.html
+++ b/private/index.html
@@ -25,10 +25,10 @@
 
     DG.then(function () {
         map = DG.map('map', {
-            center: new DG.LatLng(54.980156831455, 82.897440725094),
+            center: [54.980156831455, 82.897440725094],
             zoom: 13,
             geoclicker: true,
-            worldCopyJum: true,
+            worldCopyJump: true,
             zoomControl: false,
             fullscreenControl: false
         });

--- a/src/DGAttribution/skin/basic/less/dg-mapcopyright.less
+++ b/src/DGAttribution/skin/basic/less/dg-mapcopyright.less
@@ -1,9 +1,5 @@
 .dg-attribution {
     background-color: transparent !important;
-
-    .leaflet-touch & {
-        margin-top: 90px;
-        }
     }
     .dg-attribution__copyright {
         margin: 0 55px 5px 0;

--- a/src/DGCustomization/skin/basic/less/dg-zoom.less
+++ b/src/DGCustomization/skin/basic/less/dg-zoom.less
@@ -1,11 +1,6 @@
-
 .dg-zoom {
     width: 40px;
     height: 74px;
-
-    .leaflet-bottom & {
-        margin-bottom: 40px;
-        }
     }
     .dg-zoom__in {
         position: absolute;

--- a/src/DGCustomization/src/DGZoom.js
+++ b/src/DGCustomization/src/DGZoom.js
@@ -2,11 +2,6 @@ DG.Control.Zoom.include(DG.Locale);
 DG.Control.Zoom.Dictionary = {};
 
 DG.Control.Zoom.include({
-    // Sets default zoom position from current theme
-    options: {
-        position: DG.Browser.touch ? 'bottomright' : 'topleft'
-    },
-
     // TODO: think about pull request to leaflet with zoom control button's titles as options
     onAdd: function (map) {
         var zoomName = 'dg-zoom',

--- a/src/DGFullScreen/src/DGFullScreen.js
+++ b/src/DGFullScreen/src/DGFullScreen.js
@@ -5,7 +5,7 @@ DG.Control.Fullscreen = DG.RoundControl.extend({
     },
 
     options: {
-        position: DG.Browser.touch ? 'bottomright' : 'topright',
+        position: 'topright',
         iconClass: 'fullscreen'
     },
 

--- a/src/DGRulerControl/src/Control.Ruler.js
+++ b/src/DGRulerControl/src/Control.Ruler.js
@@ -1,7 +1,7 @@
 DG.Control.Ruler = DG.RoundControl.extend({
 
     options: {
-        position: DG.Browser.touch ? 'topright' : 'topright',
+        position: 'topright',
         iconClass: 'ruler'
     },
 

--- a/src/DGTrafficControl/src/Control.Traffic.js
+++ b/src/DGTrafficControl/src/Control.Traffic.js
@@ -3,7 +3,7 @@
 DG.Control.Traffic = DG.RoundControl.extend({
 
     options: {
-        position: DG.Browser.touch ? 'topright' : 'topright',
+        position: 'topright',
         iconClass: 'traffic'
     },
 


### PR DESCRIPTION
Теперь стандартные позиции контролов всегда будут одинаковыми и на декстопах и на девайсах.

Проблема была в том, что карта на всю страницу - это достаточно редкий кейс и во многих случаях наша верстка может ломаться, например:

![screenshot from 2015-03-17 13 01 01](https://cloud.githubusercontent.com/assets/3996552/6682646/9647dd80-cc9d-11e4-9044-e0c612cac20a.png)

Думаю, пользователям лучше самим настраивать вид для мобильных устройств, если они того пожелают.