### PR TITLE
Filter project list

### DIFF
--- a/gulp/tasks/loadProjectList.js
+++ b/gulp/tasks/loadProjectList.js
@@ -37,9 +37,7 @@ gulp.task('loadProjectList', function (cb) {
 
         var data = JSON.parse(body);
 
-        var projects = data.result.items.filter(function(project) {
-            return project.bound !== null;
-        });
+        var projects = data.result.items;
 
         var projectListString = 'DG.fallbackProjectsList = JSON.parse(\'' +
             JSON.stringify(projects) +

--- a/private/loader.js
+++ b/private/loader.js
@@ -167,7 +167,7 @@
 
         url = url.replace(/^https?\:/, protocol);
 
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
             DG.ajax(url, {
                 type: 'get',
 
@@ -180,9 +180,7 @@
                     var result = data.result;
 
                     if (result && result.items && result.items.length) {
-                        DG.projectsList = result.items.filter(function (project) {
-                            return project.bounds;
-                        });
+                        DG.projectsList = result.items;
                     }
 
                     resolve();

--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -91,6 +91,22 @@ DG.ProjectDetector = DG.Handler.extend({
         ];
     },
 
+    _checkProject: function (project) {
+        function check(value) {
+            return value !== undefined && value !== null;
+        }
+
+        return project &&
+                project.bounds &&
+                check(project.code) &&
+                check(project.domain) &&
+                check(project.country_code) &&
+                project.zoom_level &&
+                    check(project.zoom_level.min) &&
+                    check(project.zoom_level.max) &&
+                project.time_zone &&
+                    check(project.time_zone.offset);
+    },
 
     _loadProjectList: function () {
         var self = this;
@@ -100,26 +116,28 @@ DG.ProjectDetector = DG.Handler.extend({
         }
         delete DG.fallbackProjectsList;
 
-        this._projectList = DG.projectsList.map(function (project) {
-            var bound = self._wktToBnd(project.bounds);
-            var latLngBounds = new DG.LatLngBounds(bound);
+        this._projectList = DG.projectsList
+            .filter(self._checkProject)
+            .map(function (project) {
+                var bound = self._wktToBnd(project.bounds);
+                var latLngBounds = new DG.LatLngBounds(bound);
 
-            /* eslint-disable camelcase */
-            return {
-                code: project.code,
-                minZoom: project.zoom_level.min,
-                maxZoom: project.zoom_level.max,
-                timeOffset: project.time_zone.offset,
-                bound: bound,
-                latLngBounds: latLngBounds,
-                traffic: !!project.flags.traffic,
-                transport: !!project.flags.public_transport,
-                roads: !!project.flags.road_network,
-                country_code: project.country_code,
-                domain: project.domain
-            };
-            /* eslint-enable camelcase */
-        });
+                /* eslint-disable camelcase */
+                return {
+                    code: project.code,
+                    minZoom: project.zoom_level.min,
+                    maxZoom: project.zoom_level.max,
+                    timeOffset: project.time_zone.offset,
+                    bound: bound,
+                    latLngBounds: latLngBounds,
+                    traffic: !!project.flags.traffic,
+                    transport: !!project.flags.public_transport,
+                    roads: !!project.flags.road_network,
+                    country_code: project.country_code,
+                    domain: project.domain
+                };
+                /* eslint-enable camelcase */
+            });
     },
 
     _searchProject: function () {


### PR DESCRIPTION
>Пример: включили Харьков, у него не указаны поля timezone и bounds (равны null). При этом jsapi очень рассчитывает на их наличие и корректное содержимое, из-за чего падаем по ошибке: Cannot read property 'replace' of null.

>Надо проверять проекты при получении и если данные проекта не удовлетворяют некоторым условиям - исключать проект из списка.

* Теперь regionList будет проверяться только при инициализации на клиенте.
* Да этого regionList уже фильтровался, но неправильно `project.bounds`, а не `project.bound`.