### PR TITLE
IE don't work on cyrillic domains

### DIFF
--- a/private/loader.js
+++ b/private/loader.js
@@ -169,9 +169,10 @@
 
         return new Promise(function (resolve) {
             DG.ajax(url, {
-                type: 'get',
+                type: DG.ajax.corsSupport ? 'get' : 'jsonp',
 
                 data: {
+                    format: DG.ajax.corsSupport ? 'json' : 'jsonp',
                     key: '__WEB_API_KEY__',
                     fields: '__REGION_LIST_FIELDS__'
                 },

--- a/src/DGAjax/src/DGAjax.js
+++ b/src/DGAjax/src/DGAjax.js
@@ -442,7 +442,9 @@ DG.ajax = (function () {
 
     var testxhr = win[xmlHttpRequest] ? new XMLHttpRequest() : null;
 
-    Ajax.corsSupport = !(!(testxhr && 'withCredentials' in testxhr) && !win[xDomainRequest]);
+    Ajax.corsSupport = !(!(testxhr && 'withCredentials' in testxhr) && !win[xDomainRequest]) &&
+        // cors not available in IE and with cyrillic domain
+        !(DG.Browser.ie && document.location.host.toLowerCase().search(/[а-я]/) != -1);
 
     return Ajax;
 })();

--- a/src/DGGeoclicker/src/provider/CatalogApi.js
+++ b/src/DGGeoclicker/src/provider/CatalogApi.js
@@ -122,7 +122,7 @@ DG.Geoclicker.Provider.CatalogApi = DG.Class.extend({
         this.cancelLastRequest();
 
         if (!DG.ajax.corsSupport) {
-            type = data.output = 'jsonp';
+            type = data.format = 'jsonp';
         }
 
         this._lastRequest = DG.ajax(url, {


### PR DESCRIPTION
Оказывается, IE для кириллических доменов не умеет сравнивать параметр `Access-Control-Allow-Origin`, когда используется CORS. Теперь в таких ситуациях будет отправляться jsonp запрос.