### PR TITLE
Fix bug with __dgApi__ in IE9

### DIFF
--- a/private/loader.js
+++ b/private/loader.js
@@ -230,11 +230,11 @@
     }
 
     window.DG.then = function (resolve, reject) {
+        window.__dgApi__.callbacks.push([resolve, reject]);
+
         if (isLazy && !isJSRequested) {
             requestJS();
         }
-
-        window.__dgApi__.callbacks.push([resolve, reject]);
 
         if (reject) {
             rejects.push(reject);


### PR DESCRIPTION
Скрипт кешировался и вызывался синхронно и удалял `__dgApi__`.