### PR TITLE
Load .json files via require instead of JSON.parse(fs.readFileSync(...))

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -70,15 +70,13 @@ function getAppConfig() { // ()->Object
         mainConfig,
         localConfig;
 
-    if (!fs.existsSync(mainConfigPath)) {
-        throw new Error('File \'config.main.json\' was not found in ' + mainConfigPath);
-    }
+    mainConfig = require(mainConfigPath);
 
-    mainConfig = JSON.parse(fs.readFileSync(mainConfigPath));
-    if (fs.existsSync(localConfigPath)) {
-        localConfig = JSON.parse(fs.readFileSync(localConfigPath));
+    try {
+        localConfig = require(localConfigPath);
         extend(true, mainConfig, localConfig);
-    }
+    } catch (e) {}
+
     return mainConfig;
 }
 

--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -70,9 +70,7 @@ DG.ProjectDetector = DG.Handler.extend({
         var arr,
             pointsArr,
             bracketsContent,
-            regExp,
-            southWest,
-            northEast;
+            regExp;
 
         wkt = wkt.replace(/, /g, ',');
         wkt.replace(' (', '(');


### PR DESCRIPTION
Парни, зачем тут так сложно грузить файлы, проверять их наличие https://github.com/2gis/mapsapi/blob/master/build/config.js#L77

Достаточно просто использовать `require` чтобы загрузить `.json`-файл.