### PR TITLE
Method panInsideBounds doesn't accept param in array form

### DIFF
--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -93,6 +93,7 @@ DG.Map.include({
     },
 
     getBoundsZoom: function (bounds, inside, padding) {
+        bounds = DG.latLngBounds(bounds);
         this._restrictZoom(bounds);
         return getBoundsZoom.call(this, bounds, inside, padding);
     },


### PR DESCRIPTION
Если выполнить в консоли 
`map.panInsideBounds([ [54.9801, 82.8974], [54.9901, 82.9074] ])` получим 
```
Uncaught TypeError: undefined is not a function
```
Если сделать так:
```
var southWest = DG.latLng(54.9801, 82.8974),
    northEast = DG.latLng(54.9901, 82.9074),
    bounds = DG.latLngBounds(southWest, northEast);
map.panInsideBounds(bounds);
```
То всё норм.
А в доке написано:
```
Все методы, которые принимают объекты LatLngBounds также принимают их в виде простого массива, то есть границы могут быть указаны как в этом примере:

map.fitBounds([
    [54.9801, 82.8974],
    [54.9901, 82.9074]
]);
```