### PR TITLE
Fix ie9 double then problem before map initialize

### DIFF
--- a/private/loader.js
+++ b/private/loader.js
@@ -226,11 +226,11 @@
         version: version
     };
 
-    if (!isLazy) {
-        requestJS();
-    }
+    var loaderDgThen = window.DG.then = function (resolve, reject) {
+        if (DG.then !== loaderDgThen) {
+            return DG.then(resolve, reject);
+        }
 
-    window.DG.then = function (resolve, reject) {
         window.__dgApi__.callbacks.push([resolve, reject]);
 
         if (isLazy && !isJSRequested) {
@@ -244,4 +244,7 @@
         return this;
     };
 
+    if (!isLazy) {
+        requestJS();
+    }
 })();


### PR DESCRIPTION
If you initialize code looks like:
```js
loaderScript.onload = function () {
    dgMaps = window.DG;
    if (pluginList) {
        dgMaps = dgMaps.then(function() {
            return window.DG.plugin(pluginList);
        });
    }
    dgMaps.then(function() {
        dgMaps = window.DG;
        resolve();
    });
};
```
IE9 calls cached script synchronously and second `dgMaps.then` throw error, because DG initialize script removed `__dgApi__` object from `window`.

Now `DG.then` from `loader.js` will be check to appearance new `DG.then` in `window` (from DG initialize script).