### PR TITLE
Ruler labels in IE8

### DIFF
--- a/gulp/util/destCSS.js
+++ b/gulp/util/destCSS.js
@@ -59,7 +59,7 @@ module.exports = function(opt, cb) {
             .pipe(list.name ? rename({suffix: '.' + list.name}) : util.noop())
             .pipe(gulp.dest('public/css/'))
             .pipe(rename({suffix: '.min'}))
-            .pipe(minifyCss())
+            .pipe(minifyCss({compatibility: 'ie8'}))
             .pipe(header(config.copyright))
             .pipe(list.size ? map(stat.save) : util.noop())
             .pipe(gulp.dest('public/css/'));

--- a/src/DGRuler/skin/basic/less/dg-ruler.ie.less
+++ b/src/DGRuler/skin/basic/less/dg-ruler.ie.less
@@ -1,3 +1,7 @@
 .dg-ruler__point {
     .repeatableBg('DGRuler__point');
     }
+
+.dg-ruler__label-container {
+    background: #0da5d5;
+    }


### PR DESCRIPTION
Comrades, ruler meters label colors broken. 
![line](https://cloud.githubusercontent.com/assets/9331669/7367882/6d77c060-edbc-11e4-8776-bda79b37fc26.PNG)
