### PR TITLE
Add gulp task for test build

### DIFF
--- a/gulp/tasks/buildTestFunc.js
+++ b/gulp/tasks/buildTestFunc.js
@@ -1,0 +1,18 @@
+var runSequence = require('run-sequence');
+var gulp = require('gulp');
+
+var buildEnd = require('../util/buildEnd.js');
+
+gulp.task('buildTestFunc', function (cb) {
+    global.isConcatJS = true;
+
+    runSequence('clean', [
+        'buildTestScripts',
+        'buildTestStyles',
+        'doc',
+        'copyPrivateAssets'
+    ], function () {
+        buildEnd();
+        cb();
+    });
+});

--- a/gulp/tasks/buildTestScripts.js
+++ b/gulp/tasks/buildTestScripts.js
@@ -1,6 +1,12 @@
 var redust = require('gulp-redust');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+var header = require('gulp-header');
+var footer = require('gulp-footer');
 var file = require('gulp-file');
 var map = require('map-stream');
+var gulpif = require('gulp-if');
+var util = require('gulp-util');
 var gulp = require('gulp');
 
 var config = require('../../build/config.js');
@@ -10,11 +16,36 @@ var error = require('../util/error');
 var stat = require('../util/stat');
 
 gulp.task('buildTestScripts', ['loadProjectList', 'lintJS', 'buildLeaflet'], function () {
-    return gulp.src(deps.getJSFiles(), {base: '.'})
+    var pkg = 'full';
+    var isConcat = global.isConcatJS;
+
+    // no loading tiles
+    config.appConfig.tileServer = '';
+
+    var stream = gulp.src(deps.getJSFiles({pkg: pkg}), {base: '.'})
         .pipe(error.handle())
-        .pipe(file('projectList.js', projectList.get()))
-        .pipe(file('config.js', 'DG.config = ' + JSON.stringify(config.appConfig) + ';'))
-        .pipe(redust(config.tmpl))
+        .pipe(redust(config.tmpl));
+
+    if (isConcat) {
+        stream = stream
+            .pipe(concat('script.' + pkg + '.js'))
+            .pipe(header(config.js.intro))
+            .pipe(footer(projectList.get()))
+            .pipe(footer('DG.config = ' + JSON.stringify(config.appConfig) + ';'))
+            .pipe(footer(config.js.outro))
+    } else {
+        stream = stream
+            .pipe(file('projectList.js', projectList.get()))
+            .pipe(file('config.js', 'DG.config = ' + JSON.stringify(config.appConfig) + ';'));
+    }
+
+    stream = stream.pipe(gulpif(util.env.release, uglify()));
+
+    if (isConcat) {
+        stream = stream.pipe(header(config.copyright))
+    }
+
+    return stream
         .pipe(map(stat.save))
-        .pipe(gulp.dest('build/tmp/testJS'));
+        .pipe(gulpif(isConcat, gulp.dest('public/js/'), gulp.dest('build/tmp/testJS')));
 });

--- a/gulp/util/destCSS.js
+++ b/gulp/util/destCSS.js
@@ -21,7 +21,8 @@ module.exports = function (opt) {
                 suffix: browser === 'ie8' ? 'ie8' : null,
                 pkg: util.env.pkg || 'full',
                 skin: util.env.skin || config.appConfig.defaultSkin,
-                ie8: browser === 'ie8'
+                ie8: browser === 'ie8',
+                isTest: opt.isTest
             };
         });
     } else {
@@ -32,21 +33,15 @@ module.exports = function (opt) {
                         suffix: [pkg, skin, browser].join('.').replace(/\.$/, ''),
                         pkg: pkg,
                         skin: skin,
-                        ie8: browser === 'ie8'
+                        ie8: browser === 'ie8',
+                        isTest: opt.isTest
                     });
                 });
             });
         });
     }
 
-    var testRules = [{
-        isTest: true,
-        ie8: true
-    }];
-
-    var cssBuildRules = opt.isTest ? testRules : buildRules;
-
-    return cssBuildRules.map(function (buildRule) {
+    return buildRules.map(function (buildRule) {
         return buildCSS(buildRule).pipe(gulp.dest('public/css/'));
     }).reduce(function (prev, next) {
         return es.merge(prev, next);

--- a/src/DGCustomization/test/DGMap.BaseLayerSpec.js
+++ b/src/DGCustomization/test/DGMap.BaseLayerSpec.js
@@ -10,14 +10,6 @@ describe('DG.TileLayer', function() {
     });
 
     describe('check init', function() {
-        it('should tile url contain \'2gis\'', function() {
-            var img = map.getPane('mapPane').getElementsByTagName('img');
-
-            expect(img.length > 0).to.be.ok();
-
-            expect(img[0].getAttribute('src')).contain('2gis');
-        });
-
         it('should be map.baseLayer', function() {
             expect(map.baseLayer).to.be.a('object');
         });


### PR DESCRIPTION
As shows online test practice good opportunity to speed up functional tests is disable tail loads.  