### PR TITLE
Developer build with server restarts

### DIFF
--- a/gulp/tasks/dev.js
+++ b/gulp/tasks/dev.js
@@ -1,0 +1,8 @@
+var runSequence = require('run-sequence');
+var gulp = require('gulp');
+
+var buildEnd = require('../util/buildEnd.js');
+
+gulp.task('dev', function (cb) {
+    runSequence('build', 'server', 'watch', cb);
+});

--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -1,0 +1,25 @@
+var gulp = require('gulp');
+
+var spawn = require('child_process').spawn;
+
+var server = null;
+
+gulp.task('server', function(cb) {
+    function start() {
+        server = spawn('node', ['app'], {stdio: 'inherit'});
+        cb();
+    }
+
+    if (server) {
+        server.once('close', start);
+        server.kill();
+    } else {
+        start();
+    }
+});
+
+process.on('exit', function() {
+    if (server) {
+        server.kill();
+    }
+});

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -3,9 +3,26 @@ var destCSS = require('../util/destCSS');
 var runSequence = require('run-sequence');
 
 gulp.task('watch', function () {
-    gulp.watch('private/*.*', ['copyPrivateAssets']);
-    gulp.watch('vendors/leaflet/src/**/*.*', ['buildLeaflet']);
     gulp.watch('src/doc/**/*.*', ['doc']);
-    gulp.watch('src/**/*.js', ['buildScripts']);
-    gulp.watch('src/**/*.less', ['rebuildCSS']);
+
+    gulp.watch('private/*.*', function () {
+        runSequence('copyPrivateAssets', 'server');
+    });
+
+    gulp.watch([
+        'src/**/*.js',
+        'vendors/leaflet/src/**/*.*'
+    ], function () {
+        runSequence('buildScripts', 'server');
+    });
+
+    gulp.watch('src/**/*.less', function () {
+        runSequence('rebuildCSS', 'server');
+    });
+
+    gulp.watch('config.main.json', function () {
+        runSequence('build', 'server');
+    });
+
+    gulp.watch(['app.js', 'config.local.json'], ['server']);
 });


### PR DESCRIPTION
Сейчас при изменении JS или CSS файлов результаты пересборки сохраняются на диск в папку `public`. Но так как сервер грузит файлы с диска только один раз при запуске, его необходимо перезапускать вручную.

Нужно сделать полноценную dev-сборку, которая будет автоматически запускать отслеживание файлов и перезапускать сервер при их изменении.