### PR TITLE
Accuracy of the map makes error in region detection

### DIFF
--- a/src/DGProjectDetector/test/ProjectDetectorInSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorInSpec.js
@@ -193,7 +193,7 @@ describe('DG.ProjectDetectorIn', function () {
             map.setView(project1, 8);
 
             expect(map.fitBounds(new DG.LatLngBounds(edgeProject1, edgeProject2))).to.be(map);
-            expect(map.getZoom()).to.be(maxDesertZoom);
+            expect(map.getZoom()).to.be(14);
         });
 
         it('bound on project1 from project1 small zoom', function () {

--- a/src/DGProjectDetector/test/ProjectDetectorOutOfWorldSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorOutOfWorldSpec.js
@@ -193,7 +193,7 @@ describe('DG.ProjectDetectorOut', function () {
             map.setView(project1, 8);
 
             expect(map.fitBounds(new DG.LatLngBounds(edgeProject1, edgeProject2))).to.be(map);
-            expect(map.getZoom()).to.be(maxDesertZoom);
+            expect(map.getZoom()).to.be(14);
         });
 
         it('bound on project1 from project1 small zoom', function () {

--- a/src/DGProjectDetector/test/ProjectDetectorUnderSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorUnderSpec.js
@@ -193,7 +193,7 @@ describe('DG.ProjectDetectorUnder', function () {
             map.setView(project1, 8);
 
             expect(map.fitBounds(new DG.LatLngBounds(edgeProject1, edgeProject2))).to.be(map);
-            expect(map.getZoom()).to.be(maxDesertZoom);
+            expect(map.getZoom()).to.be(14);
         });
 
         it('bound on project1 from project1 small zoom', function () {


### PR DESCRIPTION
Например, город Томск, берем точку `extremePoint` - точка на границе, она попадает в проект, все хорошо:
```
var extremePoint = [56.488128, 84.768656];
var bound = DG.Wkt.geoJsonLayer('POLYGON((84.768656 56.588195,85.235419 56.595694,85.246532 56.355457,84.782704 56.348026,84.768656 56.588195))').getBounds();
bound.contains(extremePoint) // true
```
Если эту же точку сделать центром карты и определить попадает ли центр в баунд проекта, то видим такую картину:
``` 
map.setView(extremePoint);
console.log(map.getCenter()) 
bound.contains(map.getCenter()) // false
```

За счет увеличения точности (см.что будет выведено) точка уже вне проекта и при выставлении центра в эту точку карта задает maxZoom = 13, потому что определяет проект исходя из положения центра. Может быть, при определении использовать пересечение баундов?