### PR TITLE
Use own tracker analytics name

### DIFF
--- a/src/DGCore/src/DGCore.js
+++ b/src/DGCore/src/DGCore.js
@@ -30,8 +30,8 @@ DG.Map.addInitHook(function () {
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script',DG.config.protocol+DG.config.googleAnalytics,'ga');
 
-    ga('create', DG.config.gaCode, 'none');
-    ga('send', 'pageview');
+    ga('create', DG.config.gaCode, 'none', {name: 'mapsapi2gis'});
+    ga('mapsapi2gis.send', 'pageview');
     /*eslint-enable */
 
     var newImg = new Image();


### PR DESCRIPTION
После недавних изменений в mapsapi, аналитика начинает грузиться только после инициализации карты. В тоже самое время, аналитика может начать грузиться с сайта, куда вставлена mapsapi. Это может вызывать проблемы.

Поправил в соответствии с этим https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced

Ссылка на объяснения проблемы https://code.google.com/p/analytics-issues/issues/detail?id=472