### PR TITLE
Traffic control hover

### DIFF
--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
@@ -24,6 +24,10 @@
             0 1px 0 0 #fff;
         }
 
+    .no-touch &:hover {
+        color: #f2f2f2;
+    }
+
     .no-touch &_color_green:hover:after,
     .no-touch &_color_yellow:hover:after,
     .no-touch &_color_red:hover:after {


### PR DESCRIPTION
Maybe should think about traffic control behavior. Because now difficult see traffic value in pressed hovered control.
![api - google chrome_069](https://cloud.githubusercontent.com/assets/9331669/7367806/b3bc61bc-edbb-11e4-93a7-e2a5725fff66.png)
