### PR TITLE
Afеter zoom in by double click in IE shows popup

### DIFF
--- a/src/DGGeoclicker/src/DGGeoclicker.js
+++ b/src/DGGeoclicker/src/DGGeoclicker.js
@@ -80,6 +80,14 @@ DG.Geoclicker = DG.Handler.extend({
                 clearTimeout(this.pendingClick);
                 this.popupWasOpen = false;
             }
+        },
+
+        dblclick: function(e) {
+            if (DG.Browser.ielt9) {
+                this.clickCount = 0;
+                this.popupWasOpen = false;
+                clearTimeout(this.pendingClick);
+            }
         }
     },
 


### PR DESCRIPTION
To reproduce enough twice press left mouse button when geoclicker on.
Expected: Increased zoom.
Real: Increased zoom and geoclicker popup.