### PR TITLE
Get rid of data-id="dgLoader"

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <script src="__BASE_URL__/loader.js" data-id="dgLoader"></script>
+    <script src="__BASE_URL__/loader.js"></script>
 
     <style>
         html,body { height: 100%; margin: 0; padding: 0; }

--- a/app/index.js
+++ b/app/index.js
@@ -18,13 +18,20 @@ app.get('/loader.js', function(req, res) {
     var localConfig = _.cloneDeep(config.localConfig);
 
     // Set correct protocol according to GET param
-    localConfig.protocol = req.query.ssl ? 'https:' : 'http:';
+    var protocol = req.query.ssl ? 'https:' : 'http:';
+
+    localConfig.protocol = protocol;
 
     res.set('Content-Type', 'application/javascript; charset=utf-8');
     res.set('X-Powered-By', '2GIS Maps API Server');
 
-    // Send loader with injected local config
-    res.send(loader.replace(/__LOCAL_CONFIG__/g, JSON.stringify(localConfig)));
+    var result = loader
+        .replace(/__LOCAL_CONFIG__/g, JSON.stringify(localConfig))
+        .replace(/__BASE_URL__/g, protocol + config.appConfig.baseUrl)
+        .replace(/__QUERY__/g, JSON.stringify(req.query));
+
+    // Send loader with injected params
+    res.send(result);
 });
 
 // Load index file and inject base URL

--- a/app/loader.js
+++ b/app/loader.js
@@ -4,46 +4,44 @@
     var isJSRequested = false;
     var rejects = [];
     var version = 'v2.1.1';
+    var baseURL = '__BASE_URL__';
+    var query = __QUERY__;
+    var isLazy = query.lazy === 'true';
+    var qs = getQueryString();
 
-    var url = (function () {
-        var scripts = document.getElementsByTagName('script');
+    function getQueryString() {
+        var params = {
+            skin: query.skin,
+            pkg: query.pkg
+        };
 
-        for (var i = scripts.length; i;) {
-            if (scripts[--i].getAttribute('data-id') == 'dgLoader') {
-                return scripts[i].src.split('?');
+        if (/MSIE\x20(\d+\.\d+);/.test(navigator.userAgent) && parseInt(RegExp.$1, 10) < 9) {
+            params.ie8 = true;
+        }
+
+        var qsComponents = [];
+
+        for (var key in params) {
+            var value = params[key];
+
+            if (value) {
+                qsComponents.push(key + '=' + value);
             }
         }
-    })();
 
-    var baseURL = url[0].replace(/loader\.js$/, '');
-
-    // Амперсанды с обоих сторон, это позволяет делать надёжный поиск параметров через `indexOf('&name=')` и
-    // `indexOf('&name=value&')`. Без амперсандов прийдётся искать через `indexOf('name=')` и `indexOf('name=value')`,
-    // в результате можем получить ложные совпадения.
-    var urlParams = url[1] ? '&' + url[1] + '&' : '&';
-
-    if (urlParams.indexOf('&retina=') == -1) {
-        if (window.devicePixelRatio && window.devicePixelRatio >= 1.5) {
-            urlParams += 'retina=true&';
+        if (!qsComponents.length) {
+            return '';
         }
-    }
 
-    if (urlParams.indexOf('&ie8=') == -1) {
-        // IE8
-        if (/MSIE\x20(\d+\.\d+);/.test(navigator.userAgent) && parseInt(RegExp.$1, 10) < 9) {
-            urlParams += 'ie8=true&';
-        }
+        return '?' + qsComponents.join('&');
     }
-
-    var qs = '?' + urlParams.slice(1) + 'version=' + version;
-    var isLazy = urlParams.indexOf('&lazy=true&') != -1;
 
     function requestJS() {
         isJSRequested = true;
 
         var script = document.createElement('script');
         script.setAttribute('type', 'text/javascript');
-        script.setAttribute('src', baseURL + 'js/' + qs);
+        script.setAttribute('src', baseURL + '/js/' + qs);
 
         script.onerror = function (evt) {
             runRejects(evt);
@@ -119,7 +117,7 @@
     }
 
     function loadStylesheet() {
-        var url = baseURL + 'css/' + qs;
+        var url = baseURL + '/css/' + qs;
         var style = document.createElement('style');
         style.type = 'text/css';
 
@@ -137,7 +135,6 @@
                     // moment application was built. baseUrl contains current
                     // value.
                     var originalBaseUrl = '__ORIGINAL_BASE_URL__';
-                    var baseURL = DG.config.protocol + DG.config.baseUrl;
 
                     // Replace if they don't match
                     if (baseURL !== originalBaseUrl) {
@@ -230,7 +227,6 @@
             [prepareForInit, undefined],
             [setReady, undefined]
         ],
-        debug: urlParams.indexOf('&mode=debug&') != -1,
         version: version
     };
 

--- a/app/loader.js
+++ b/app/loader.js
@@ -12,7 +12,8 @@
     function getQueryString() {
         var params = {
             skin: query.skin,
-            pkg: query.pkg
+            pkg: query.pkg,
+            version: version
         };
 
         if (/MSIE\x20(\d+\.\d+);/.test(navigator.userAgent) && parseInt(RegExp.$1, 10) < 9) {

--- a/functional-tests/templates/base.html
+++ b/functional-tests/templates/base.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <title>{{title}}</title>
-        <script src="{{loaderPath}}/loader.js" data-id="dgLoader"></script>
+        <script src="{{loaderPath}}/loader.js"></script>
         <style>
             {{headStyle}}
         </style>

--- a/src/DGAjax/demo/index.html
+++ b/src/DGAjax/demo/index.html
@@ -4,7 +4,7 @@
     <title>DGAjax & DGPromise demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 </head>
 <body>
 

--- a/src/DGCore/demo/index.html
+++ b/src/DGCore/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>DG.then demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 </head>
 <body>
     <div id="map" style="width: 100%; height: 600px; border: 1px solid #ccc;"></div>

--- a/src/DGCore/src/DGCore.js
+++ b/src/DGCore/src/DGCore.js
@@ -20,7 +20,6 @@ for (var prop in oldDG) {
 
 window.__dgApi__ = window.__dgApi__ || {};
 DG.version = window.__dgApi__.version;
-DG.debug = window.__dgApi__.debug;
 DG.Icon.Default.imagePath  = '../img/vendors/leaflet';
 
 DG.Map.addInitHook(function () {

--- a/src/DGEntrance/demo/index.html
+++ b/src/DGEntrance/demo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8'>
   <title>DGEntrance demo</title>
-  <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+  <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 
 </head>
 <body>

--- a/src/DGFullScreen/demo/index.html
+++ b/src/DGFullScreen/demo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8'>
   <title>DGFullScreen Demo</title>
-  <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+  <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 
 </head>
 <body>

--- a/src/DGGeoclicker/demo/index.html
+++ b/src/DGGeoclicker/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>geoclicker demo</title>
-    <script src="http://maps.api.2gis.dev/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.dev/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGLabel/demo/index.html
+++ b/src/DGLabel/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>DGLabel demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGLocale/demo/index.html
+++ b/src/DGLocale/demo/index.html
@@ -4,7 +4,7 @@
     <title>DGLocale demo</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 </head>
 <body>
 

--- a/src/DGLocation/demo/index.html
+++ b/src/DGLocation/demo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8'>
   <title>Leaflet.Control.Locate Demo</title>
-  <script src="http://maps.api.2gis.dev/2.0/loader.js" data-id="dgLoader"></script>
+  <script src="http://maps.api.2gis.dev/2.0/loader.js"></script>
 
 </head>
 <body>

--- a/src/DGPoi/demo/index.html
+++ b/src/DGPoi/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
 
     <title>poi demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGProjectDetector/demo/index.html
+++ b/src/DGProjectDetector/demo/index.html
@@ -4,7 +4,7 @@
     <title>projectDetector demo</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 </head>
 <body>
 

--- a/src/DGRuler/demo/index.html
+++ b/src/DGRuler/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>DGRuler demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGRulerControl/demo/index.html
+++ b/src/DGRulerControl/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>DGRulerControl demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGTraffic/demo/index.html
+++ b/src/DGTraffic/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <title>DGTraffic demo</title>
-    <script src="http://maps.api.2gis.dev/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.dev/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGTrafficControl/demo/index.html
+++ b/src/DGTrafficControl/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>DGTrafficControl demo</title>
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/DGWkt/demo/index.html
+++ b/src/DGWkt/demo/index.html
@@ -4,7 +4,7 @@
     <title>DGWkt demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
     <style type="text/css">
         html,body { height: 100%; margin: 0; padding: 0; }
         #map { width: 100%; height: 100%; }

--- a/src/doc/examples/base.md
+++ b/src/doc/examples/base.md
@@ -8,7 +8,7 @@
 
 ### Создание карты
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -24,8 +24,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Создание карты</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
         <div id="map" style="width: 100%; height: 400px;"></div>
@@ -73,8 +72,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Создание карты по требованию</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js?lazy=true"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js?lazy=true"></script>
         </head>
         <body>
             <input id="create" type="button" value="Показать карту" />
@@ -104,7 +102,7 @@
 
 ### Использование опций подключения
 
-Ниже представлен пример вызова карты с таким набором опций: 'pkg=basic', 'skin=dark', 'mode=debug', 'sprite=true'. Как результат мы получим неминифицированные исходники и иконки собранные в спрайт в тёмной теме. Все возможные опции можно посмотреть в разделе [Опции подключения](/doc/maps/manual/loading/#sel=21:1,21:2). На выходе имеем такую карту:
+Ниже представлен пример вызова карты с таким набором опций: 'pkg=basic', 'skin=light'. Как результат мы получим сборку с базовой функциональностью в светлой теме. Все возможные опции можно посмотреть в разделе [Опции подключения](/doc/maps/manual/loading/#sel=21:1,21:2). На выходе имеем такую карту:
 <div id="map2" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -121,7 +119,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Использование опций подключения</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=basic&skin=dark&mode=debug&sprite=true" data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=basic&skin=light"></script>
         </head>
         <body>
         <div id="map" style="width: 100%; height: 400px;"></div>
@@ -169,8 +167,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Изменение размера карты</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <input id="changeSize" type="button" value="Изменить размер" />
@@ -226,8 +223,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отключение опций взаимодействия</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -280,8 +276,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Определение местоположения пользователя</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>

--- a/src/doc/examples/bounds.md
+++ b/src/doc/examples/bounds.md
@@ -10,7 +10,7 @@
 
 Ограничение просматриваемой области границами города Новосибирск, а также уровней масштабирования диапазоном от 10 до 15:
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -32,8 +32,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Ограничение границ и масштаба</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -97,8 +96,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Карта с левой панелью</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
             <style>
                 #container {
                     height:400px;

--- a/src/doc/examples/controls.md
+++ b/src/doc/examples/controls.md
@@ -10,7 +10,7 @@
 
 Если необходимо получить "чистую" карту, без лишних элементов управления, тогда вам поможет следующий пример:
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -28,8 +28,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Скрытие элементов управления по умолчанию</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -68,8 +67,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение элементов управления в разных частях карты</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>

--- a/src/doc/examples/events.md
+++ b/src/doc/examples/events.md
@@ -11,7 +11,7 @@
 Пример подписки на различные события (клик в маркер, карту, геометрию):
 
 Вы кликнули в: <span id="clicked_element">никуда</span>
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -52,8 +52,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Подписка на события</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             Вы кликнули в: <span id="clicked_element">никуда</span>
@@ -132,8 +131,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Подписка на изменение проекта 2ГИС</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>

--- a/src/doc/examples/external-modules.md
+++ b/src/doc/examples/external-modules.md
@@ -10,7 +10,7 @@
 
 Пример подключения кластеризатора. Кластеризатор часто используется для отображения большого количества маркеров. Код модуля и его документация доступна в <a href="https://github.com/Leaflet/Leaflet.markercluster" target="_blank">GitHub-репозитории</a> автора.
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <link rel="stylesheet" href="http://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
 <link rel="stylesheet" href="http://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
 <script src="http://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
@@ -44,7 +44,7 @@
         <head>
             <meta charset='utf-8' />
             <title>Кластеризатор</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
             <link rel="stylesheet" href="http://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
             <link rel="stylesheet" href="http://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
             <script src="http://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
@@ -104,7 +104,7 @@
         <head>
             <meta charset='utf-8' />
             <title>Тепловая карта</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
             <script src="http://maps.api.2gis.ru/2.0/heat_realworld.js"></script>
         </head>
         <body>

--- a/src/doc/examples/geocoding.md
+++ b/src/doc/examples/geocoding.md
@@ -10,7 +10,7 @@
 
 Определение координат объекта по его адресу:
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script type="text/javascript">
     DG.then(function () {
@@ -59,8 +59,7 @@
     <html>
         <head>
             <meta charset="utf-8">
-            <script src="http://maps.api.2gis.ru/2.0/loader.js?"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
 
         <body>
@@ -151,8 +150,7 @@
     <html>
         <head>
             <meta charset="utf-8">
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
 
         <body>
@@ -242,8 +240,7 @@
     <html>
         <head>
             <meta charset="utf-8">
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
 
         <body>

--- a/src/doc/examples/geojson.md
+++ b/src/doc/examples/geojson.md
@@ -10,7 +10,7 @@
 
 Отображение объектов, описанных в формате GeoJSON:
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -63,8 +63,7 @@
         <head>
             <meta charset="utf-8" />
             <title>GeoJSON</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>

--- a/src/doc/examples/geometries.md
+++ b/src/doc/examples/geometries.md
@@ -8,7 +8,7 @@
 
 ### Отображение ломаной
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 500px;"></div>
 <script>
     DG.then(function() {
@@ -36,8 +36,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение ломаной</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 500px;"></div>
@@ -100,8 +99,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение прямоугольников</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -180,8 +178,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение многоугольников</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -250,8 +247,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение круга и круглого маркера</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -311,8 +307,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Геометрии с подсказками и балунами</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -388,8 +383,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Анимация отрисовки ломаной</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <input id="playAnimation" type="button" value="Запустить анимацию" />

--- a/src/doc/examples/markers.md
+++ b/src/doc/examples/markers.md
@@ -10,7 +10,7 @@
 
 Маркер, при клике на который открывается балун с информацией:
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function () {
@@ -28,8 +28,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Маркер с балуном</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -82,8 +81,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Перетаскиваемый маркер</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             Координаты маркера: <div id="location">LatLng(54.98, 82.89)</div>
@@ -154,8 +152,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Маркер с пользовательской иконкой</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -222,8 +219,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Программное открытие маркера</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <button id='open-popup'>Открыть балун</button>
@@ -280,8 +276,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Маркер с подсказкой</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -342,8 +337,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Обработка событий группы маркеров</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -412,8 +406,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Анимированное движение маркера</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -490,8 +483,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение/удаление нескольких маркеров, fitBounds</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <input id="hide" type="button" value="hide markers" />

--- a/src/doc/examples/popups.md
+++ b/src/doc/examples/popups.md
@@ -8,7 +8,7 @@
 
 ### Открытие балуна при клике на маркер
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function () {
@@ -26,8 +26,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Открытие балуна при клике на маркер</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -78,8 +77,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Открытие балуна по умолчанию и по требованию</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <input id="showPopup" type="button" value="Открыть балун" />
@@ -144,8 +142,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Добавление нескольких балунов на карту</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -231,8 +228,7 @@
         <head>
             <meta charset="UTF-8">
             <title>Поведение балуна с параметром sprawling</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 300px; height: 150px;"></div>

--- a/src/doc/examples/wkt.md
+++ b/src/doc/examples/wkt.md
@@ -8,7 +8,7 @@
 
 ### Отображение простых геометрий
 
-<script src="http://maps.api.2gis.ru/2.0/loader.js" data-id="dgLoader"></script>
+<script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
@@ -35,8 +35,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение простых геометрий</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>
@@ -85,8 +84,7 @@
         <head>
             <meta charset="utf-8" />
             <title>Отображение составных геометрий</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js"
-            data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js"></script>
         </head>
         <body>
             <div id="map" style="width: 100%; height: 400px;"></div>

--- a/src/doc/manual/loading.md
+++ b/src/doc/manual/loading.md
@@ -10,9 +10,7 @@
 
 Сперва подключим API карт, поместив в секцию `head` HTML-страницы следующий код:
 
-    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full" data-id="dgLoader"></script>
-
-Атрибут `data-id="dgLoader"` обязательный.
+    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full"></script>
 
 Затем воспользуемся функцией `DG.then`, в которую поместим код инициализации карты:
 
@@ -29,7 +27,7 @@
 
 Вы можете загрузить API карт именно в тот момент, когда карта станет нужна. Для этого в URL подключения API необходимо добавить параметр `lazy=true`:
 
-    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full&lazy=true" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full&lazy=true"></script>
 
 Затем в нужный момент времени (например, при нажатии на кнопку) необходимо вызвать функцию DG.then:
 

--- a/src/doc/manual/migration.md
+++ b/src/doc/manual/migration.md
@@ -30,7 +30,7 @@ DG.autoload(function() {
 });</code></pre>
             </td>
             <td>
-<pre><code>&lt;script src=&quot;http://maps.api.2gis.ru/2.0/loader.js?pkg=full" data-id=&quot;dgLoader&quot;&gt;&lt;/script&gt;
+<pre><code>&lt;script src=&quot;http://maps.api.2gis.ru/2.0/loader.js?pkg=full"&gt;&lt;/script&gt;
 
 DG.then(function() {
     // инициализация карты

--- a/src/doc/quickstart/quickstart.md
+++ b/src/doc/quickstart/quickstart.md
@@ -14,7 +14,7 @@
 
 Для подключения JavaScript кода API добавьте в секцию head HTML-страницы следующий код:
 
-    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full" data-id="dgLoader"></script>
+    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full"></script>
 
 ### Создайте контейнер карты
 
@@ -87,7 +87,7 @@
         <head>
             <meta charset=utf-8 />
             <title>API карт 2ГИС</title>
-            <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full" data-id="dgLoader"></script>
+            <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full"></script>
             <script type="text/javascript">
                 var map;
         


### PR DESCRIPTION
With the loader now being generated dynamically, we can now drop the requirement of adding `data-id="dgLoader"` attribute to loader script element.