### PR TITLE
Fix non-clickable VML layers in IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "html5shiv": "^3.7.2",
     "image-size": "0.3.5",
     "less": "^2.4.0",
-    "leaflet": "git://github.com/Leaflet/Leaflet.git#cc04a82be1d2bd830e2cdb5755013f510b089196",
+    "leaflet": "git://github.com/Leaflet/Leaflet.git#1bb1b5a3f8307b4460211f340281b764a24a13cc",
     "lodash": "^2.4.1",
     "map-stream": "0.1.0",
     "marked": "0.3.3",

--- a/src/DGGeoclicker/src/handler/CityArea.js
+++ b/src/DGGeoclicker/src/handler/CityArea.js
@@ -3,7 +3,6 @@ DG.Geoclicker.Handler.CityArea = DG.Geoclicker.Handler.Default.extend({
     _polylineStyleDefault : {
         fillColor: '#ff9387',
         color: '#ff9387',
-        clickable: false,
         noClip: true,
         opacity: 1
     },
@@ -45,21 +44,13 @@ DG.Geoclicker.Handler.CityArea = DG.Geoclicker.Handler.Default.extend({
 
         this._geometryZoomStyle = this._getPolyStyleNum();
         this._geometry = DG.Wkt.geoJsonLayer(results[type].geometry.selection, {
-            style: this._polylineStyles[this._geometryZoomStyle]
+            style: this._polylineStyles[this._geometryZoomStyle],
+            interactive: false
         }).addTo(this._map);
 
         this._map
             .on('zoomend', this._updateGeometry, this)
             .once('popupclose', this._clearPopup, this);
-
-        // We have to manually propagate clicks through the vector layer because
-        // VML doesn't support pointer-events: none
-        if (DG.Browser.ielt9) {
-            this._geometry.on('click', function (e) {
-                this._clearPopup();
-                this._map.fire('click', e);
-            }, this);
-        }
 
         return Promise.resolve(this._fillCityAreaObject(results, type));
     },


### PR DESCRIPTION
В `Leaflet` смёржили мой фикс, так что обновил версию зависимости и убрал временный костыль на нашей стороне.