### PR TITLE
Не срабатывает map.invalidateSize

### DIFF
--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -30,6 +30,10 @@ DG.Map.include({
         this._layers = {};
         this._zoomBoundLayers = {};
 
+        // initialize _sizeChanged, before init BaseLayer
+        // see https://github.com/2gis/mapsapi/pull/264
+        this._sizeChanged = true;
+
         this.callInitHooks();
 
         this._addLayers(options.layers);
@@ -38,7 +42,6 @@ DG.Map.include({
             this.setView(L.latLng(options.center), options.zoom, {reset: true});
         }
 
-        this._sizeChanged = true;
     },
 
     setView: function (center, zoom, options) {

--- a/src/DGCustomization/test/DGMapSpec.js
+++ b/src/DGCustomization/test/DGMapSpec.js
@@ -10,6 +10,7 @@ describe('DGMap', function () {
 
     document.body.appendChild(mapContainer);
     map.setLang('ru');
+    map.invalidateSize();
 
     after(function () {
         mapContainer.parentElement.removeChild(mapContainer);


### PR DESCRIPTION
Метод `map.invalidateSize` не срабатывает после инициализации карты, т.к. при его вызове `map._sizeChanged = true` и метод не может использовать старые размеры для сравнения с новыми.

В лифлете `map._sizeChange` становится в `false` после добавления `L.TileLayer`, у нас же он добавляется в инит хуках карты.