### PR TITLE
Set z-index 0 to baselayer

### DIFF
--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -14,7 +14,8 @@ DG.Map.addInitHook(function () {
         errorTileUrl: this.getLang() === 'ru' ? errorRuUrl : errorUrl,
         detectRetina: DG.config.detectRetina,
         maxZoom: 19,
-        maxNativeZoom: 19
+        maxNativeZoom: 19,
+        zIndex: 0
     }).addTo(this);
 
     function updateErrorTileUrl() {

--- a/src/DGCustomization/test/DGMap.BaseLayerSpec.js
+++ b/src/DGCustomization/test/DGMap.BaseLayerSpec.js
@@ -13,5 +13,11 @@ describe('DG.TileLayer', function() {
         it('should be map.baseLayer', function() {
             expect(map.baseLayer).to.be.a('object');
         });
+
+        it('should be zIndex 0 on layer container', function() {
+            var layerContainer = map.baseLayer._container;
+
+            expect(Number(layerContainer.style.zIndex)).to.be(0);
+        });
     });
 });

--- a/src/DGCustomization/test/DGMap.BaseLayerSpec.js
+++ b/src/DGCustomization/test/DGMap.BaseLayerSpec.js
@@ -1,20 +1,20 @@
-describe('DG.TileLayer', function() {
+describe('DG.TileLayer', function () {
     var mapContainer = document.createElement('div'),
         map = new DG.Map(mapContainer, {
             center: [54.980206086231, 82.898068362003],
             zoom: 15
         });
 
-    after(function() {
+    after(function () {
         mapContainer = map = null;
     });
 
-    describe('check init', function() {
-        it('should be map.baseLayer', function() {
+    describe('check init', function () {
+        it('should be map.baseLayer', function () {
             expect(map.baseLayer).to.be.a('object');
         });
 
-        it('should be zIndex 0 on layer container', function() {
+        it('should be zIndex 0 on layer container', function () {
             var layerContainer = map.baseLayer._container;
 
             expect(Number(layerContainer.style.zIndex)).to.be(0);


### PR DESCRIPTION
Лифлет выставляет `zIndex` для `tileLayer` равный `options.maxZoom`. Из-за этого в некоторых случаях траффик показывался под `baseLayer`.

Решено было выставлять напрямую при создании `baseLayer` `zIndex` равный 0.