### PR TITLE
Free space in balloon with maxHeight

### DIFF
--- a/src/DGPopup/src/DGPopup.js
+++ b/src/DGPopup/src/DGPopup.js
@@ -248,7 +248,7 @@
                 this._scrollerWrapper.style.height = innerHeight + 'px';
 
                 this._updateScrollPosition();
-            } else {
+            } else if (!this._isContentHeightEnough()) {
                 this._initBaronScroller();
                 this._initBaron();
             }


### PR DESCRIPTION
code of example
```js
ment.getElementById('minWidth').onclick = function () {
                        DG.popup({
                            maxHeight: 300
                        })
                        .setLatLng(latLng)
                        .setContent('Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptas numquam distinctio impedit, quod totam eveniet dolorum qui? Corporis praesentium ipsum officiis impedit quas, inventore laboriosam ipsam nobis soluta maxime delectus quasi voluptatem, tenetur obcaecati laudantium error. Velit expedita, reprehenderit natus nihil cupiditate doloribus quis? In obcaecati cupiditate vero laudantium maiores.')
                        .openOn(map);
```
![123](https://cloud.githubusercontent.com/assets/9331669/9625373/15671ecc-516f-11e5-88f7-02e9f86317ca.png)

Also not necessary add baron in popup if maxHeight enough for balloon content.