### PR TITLE
remove gemnasium, fix coveralls badge, remove coveralls config

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-ci
-repo_token: va64PLOmYsCCJltbYFV2gJEjYaoa9f5uN

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-API карт 2GIS [![Build Status](https://travis-ci.org/2gis/mapsapi.svg?branch=master)](https://travis-ci.org/2gis/mapsapi) [![Coverage Status](https://img.shields.io/coveralls/2gis/mapsapi.svg)](https://coveralls.io/r/2gis/mapsapi) [![Dependency Status](https://gemnasium.com/2gis/mapsapi.svg)](https://gemnasium.com/2gis/mapsapi)
+API карт 2GIS [![Build Status](https://travis-ci.org/2gis/mapsapi.svg?branch=master)](https://travis-ci.org/2gis/mapsapi) [![Coverage Status](https://img.shields.io/coveralls/2gis/mapsapi.svg?branch=master&service=github)](https://coveralls.io/r/2gis/mapsapi) [![Dependency Status](https://gemnasium.com/2gis/mapsapi.svg)]
 ====
 
 При помощи API карт вы сможете:


### PR DESCRIPTION
* Удалил бадж гемназиума
* Бадж coveralls теперь будет показывать только coverage мастера
* Удалил `.coveralls.yml`, он необходим только для приватных репозиториев, [2gl](https://github.com/2gis/2gl) отлично работает без него.