### PR TITLE
Mapsapi config not extends if script loaded twice

### DIFF
--- a/src/DGCore/src/DGthen.js
+++ b/src/DGCore/src/DGthen.js
@@ -1,13 +1,6 @@
 var handlers = window.__dgApi__.callbacks || [],
     chain = Promise.resolve();
 
-// dont pollute global space!
-try {
-    delete window.__dgApi__;
-} catch(e) {
-    window.__dgApi__ = undefined; // ie8 cant delete from window object
-}
-
 handlers.forEach(function (handlers) {
     chain = chain.then(handlers[0], handlers[1]);
 });


### PR DESCRIPTION
Конфиг не расширяется локальным конфигом, если скрипт mapsapi грузится дважды, например:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>double loader</title>
</head>
<body>
    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full"></script>
    <script src="http://maps.api.2gis.ru/2.0/loader.js?pkg=full"></script>
</body>
</html>
```