### PR TITLE
Move karma to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "happen": "0.1.3",
     "html5shiv": "^3.7.2",
     "image-size": "0.3.5",
+    "karma": "^0.13.10",
     "leaflet": "git://github.com/2gis/Leaflet.git#6998a11da56a796a8bbee34f00705e264ec41ff8",
     "less": "^2.4.0",
     "lodash": "^2.4.1",
@@ -69,7 +70,6 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "karma": "^0.13.10",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.2",
     "karma-expect": "^1.1.0",


### PR DESCRIPTION
Онлайн собирает командой `npm i --production` и не ставит devDependecies, соотв-но сборка падает из-за отсутствия кармы.