### PR TITLE
Map project events strange behavior in case of few projects

### DIFF
--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -170,7 +170,7 @@ DG.ProjectDetector = DG.Handler.extend({
 
     _boundInProject: function (project, checkMethod) {
         try {
-            return this.isProjectHere(this._map.getBounds(), project, checkMethod);
+            return this.isProjectHere(this._map.getCenter(), project, checkMethod);
         } catch (e) {
             return false;
         }


### PR DESCRIPTION
In case of few projects on display, projectchange got strange behavior. 
Steps to reproduce:
1.open example page
2.execute  `map.setView([ 51.64358968607138, 85.8251953125], 8)`
3.close devTools
3.press on ZoomIn control twice
Expected: Colored Горно-Алтайск project
Got: Colored Бийск project

Additional info:
Example page code
```HTML

<!DOCTYPE html>
<html>
<head>
    <title>API карт 2ГИС</title>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">

    <script src="loader.js" data-id="dgLoader"></script>

    <style>
        html,body { height: 100%; margin: 0; padding: 0; }
        #map { width: 100%; height: 100%; }
        .leaflet-touch .leaflet-bottom .dg-attribution { margin-top: 70px; }
        .leaflet-touch .leaflet-bottom .dg-zoom {margin: 40px 10px 40px 0; }
    </style>
</head>
<body>

<div id="map"></div>

<script>
   DG.then(function() {
                map = DG.map('map', {
                    center: DG.latLng(54.98, 82.89),
                    zoom: 9
                });

                // подписываемся на событие изменения текущего проекта 2GIS
                map.on('projectchange', function(e) {
                    var bounds = e.getProject().latLngBounds;
                    currentProjectBound = DG.rectangle(bounds, {
                        color:"#f03",
                        weight:1
                    }).addTo(map);
                });

                // подписываемся на событие выхода из проекта 2GIS
                map.on('projectleave', function(e) {
                    if (currentProjectBound) {
                        map.removeLayer(currentProjectBound);
                    }
                });
            });
</script>
</body>
</html>

```