### PR TITLE
Fix bug with meta layers

### DIFF
--- a/src/DGMeta/src/DGMeta.Layer.js
+++ b/src/DGMeta/src/DGMeta.Layer.js
@@ -23,7 +23,6 @@ DG.Meta.Layer = DG.Layer.extend({
 
         this._currentTile = false;
         this._currentTileData = false;
-        this._hoveredObject = null;
 
         this._origin = DG.Meta.origin(source, {
             dataFilter: this.options.dataFilter
@@ -155,7 +154,7 @@ DG.Meta.Layer = DG.Layer.extend({
     },
 
     _getHoveredObject: function (coords, mouseTileOffset) {
-        for (var i = this._currentTileData.length - 1; i >= 0; i--) {
+        for (var i = 0; i < this._currentTileData.length; i++) {
             if (DG.PolyUtil.contains(mouseTileOffset, this._currentTileData[i].geometry.coordinates[0])) {
                 return this._currentTileData[i];
             }

--- a/src/DGMeta/src/DGMeta.Origin.js
+++ b/src/DGMeta/src/DGMeta.Origin.js
@@ -12,7 +12,6 @@ DG.Meta.Origin = DG.Class.extend({
         this._requests = {};
 
         this._tileStorage = {};
-        this._dataStorage = {};
 
         options = DG.setOptions(this, options);
 
@@ -31,12 +30,7 @@ DG.Meta.Origin = DG.Class.extend({
                 self.setTileData(tileKey, self.options.dataFilter ? self.options.dataFilter(data, coord) : data);
                 delete self._requests[tileKey];
             });
-        }
-
-        if (this._tileStorage[tileKey].constructor === Object) {
-            return Object.keys(this._tileStorage[tileKey]).map(function (id) {
-                return DG.extend({geometry: this._tileStorage[tileKey][id]}, this._dataStorage[id]);
-            }, this);
+            return false;
         }
 
         return this._tileStorage[tileKey];
@@ -52,11 +46,9 @@ DG.Meta.Origin = DG.Class.extend({
                 entity.geometry = DG.Wkt.toGeoJSON(entity.geometry);
             }
             if (!this._tileStorage[key]) {
-                this._tileStorage[key] = {};
+                this._tileStorage[key] = [];
             }
-            this._tileStorage[key][entity.id] = entity.geometry;
-            delete entity.geometry;
-            this._dataStorage[entity.id] = entity;
+            this._tileStorage[key].push(entity);
         }, this);
 
         return this;
@@ -64,7 +56,6 @@ DG.Meta.Origin = DG.Class.extend({
 
     flush: function () { // () -> Object
         this._tileStorage = {};
-        this._dataStorage = {};
         Object.keys(this._requests).forEach(function (tileKey) {
             if (this[tileKey].abort) {
                 this[tileKey].abort();


### PR DESCRIPTION
Поправил баг, когда одно пои находилось на границе между двумя тайлами. В таком случае показывалась только одна из двух частей.

Совершенно не представляю зачем нужны были:
```js
this._dataStorage
```

и

```js
if (this._tileStorage[tileKey].constructor === Object) {
    return Object.keys(this._tileStorage[tileKey]).map(function (id) {
        return DG.extend({geometry: this._tileStorage[tileKey][id]}, this._dataStorage[id]);
    }, this);
}
```

Git blame показал, что всё началось вот с этого коммита https://github.com/2gis/mapsapi/commit/41a9d3eb5846e46547040642d7637cb25552a7f3 к которому нет не единого описания.