### PR TITLE
DGProjectDetector: projectleave on map init

### DIFF
--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -2,7 +2,7 @@ DG.ProjectDetector = DG.Handler.extend({
     initialize: function (map) { // (Object)
         this._map = map;
         this._osmViewport = false;
-        this.project = null;
+        this._project = null;
         this._noProjectEventFired = false;
         this._loadProjectList();
         this._searchProject();
@@ -17,9 +17,9 @@ DG.ProjectDetector = DG.Handler.extend({
     },
 
     getProject: function () {
-        if (!this.project) { return false; }
+        if (!this._project) { return false; }
 
-        return DG.Util.extend({}, this.project);
+        return DG.Util.extend({}, this._project);
     },
 
     getProjectsList: function () {
@@ -46,25 +46,25 @@ DG.ProjectDetector = DG.Handler.extend({
     },
 
     _projectWatch: function () {
-        if (this._osmViewport === (this.project && this._boundInProject(this.project, 'contains'))) {
+        if (this._osmViewport === (this._project && this._boundInProject(this._project, 'contains'))) {
             this._osmViewport = !this._osmViewport;
             this._map.attributionControl._update(null, this._osmViewport);
         }
 
-        if (this.project && this._boundInProject(this.project) && this._zoomInProject(this.project)) { return; }
+        if (this._project && this._boundInProject(this._project) && this._zoomInProject(this._project)) { return; }
 
-        if (this.project) {
-            this.project = null;
+        if (this._project) {
+            this._project = null;
             this._map.fire('projectleave');
         }
 
         this._searchProject();
 
-        if (this.project) {
-            if (this._osmViewport === (this.project && this._boundInProject(this.project, 'contains'))) {
+        if (this._project) {
+            if (this._osmViewport === (this._project && this._boundInProject(this._project, 'contains'))) {
                 this._osmViewport = !this._osmViewport;
             }
-            this._map.attributionControl._update(null, this._osmViewport, this.project.country_code);
+            this._map.attributionControl._update(null, this._osmViewport, this._project.country_code);
         }
     },
 
@@ -179,7 +179,7 @@ DG.ProjectDetector = DG.Handler.extend({
         foundProjects.some(function (project) {
             var self = this;
 
-            this.project = project;
+            this._project = project;
             setTimeout(function () {
                 self._map.fire('projectchange', {'getProject': self.getProject.bind(self)});
             }, 1);


### PR DESCRIPTION
понадобилось событие projectleave, если при инциализации карты viewport находится вне полигона проекта-города

Если при первой загрузке карты, вьюпорт попападает в какой-то проект то выбрасывается projectchange, а если проекта нет, то ничего не происходит

немного костыльно проверяется загружена ли карта через

```
  this._map._checkIfLoaded();
```

но метод _searchProject  срабатывает дважды, первый раз карта не инициализирована и в методе leaflet'a getCenter делается _checkIfLoaded (он выбрасывает ошибку) в _boundInProject ошибка ловится и возвращается false

Второй раз уже на инициализированной карте все нормально


## Пример

http://jsfiddle.net/alekzonder/2ay3sdmf/

При инициализации срабатывает projectleave и показывается слой osm 

Если двигать карту вправо переключится на гис


