### PR TITLE
Upgrade lodash to v4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma": "^0.13.10",
     "leaflet": "git://github.com/Leaflet/Leaflet.git#c6bef03929965d15d3636999d17a7cd057ab575e",
     "less": "^2.4.0",
-    "lodash": "^2.4.1",
+    "lodash": "^4.3.0",
     "map-stream": "0.1.0",
     "marked": "0.3.3",
     "mkdirp": "0.5.0",

--- a/src/DGWkt/DGWkt.js
+++ b/src/DGWkt/DGWkt.js
@@ -1,17 +1,17 @@
 DG.Wkt = {};
 
-DG.Wkt.toGeoJSON = function (_) {
-    if (DG.Util.isArray(_)) {
-        _ = _[0];
+DG.Wkt.toGeoJSON = function (data) {
+    if (DG.Util.isArray(data)) {
+        data = data[0];
     }
-    var parts = _.split(';');
-    _ = parts.pop();
+    var parts = data.split(';');
+    data = parts.pop();
 
     var i = 0,
         srid = (parts.shift() || '').split('=').pop();
 
     function $(re) {
-        var match = _.substring(i).match(re);
+        var match = data.substring(i).match(re);
         if (!match) {
             return null;
         }


### PR DESCRIPTION
В DG.Wkt.toGeoJSON изменил название переменной с _ на data, потому что вводит в некоторое заблуждение, при поиске использования lodash по проекту. Lodash обновил до v4.3.0. Нигде не используется сейчас, но в https://github.com/2gis/mapsapi/pull/319 я использую _.chunk которого во 2ой версии lodash нету.