### PR TITLE
DGProjectDetector fix: getProject() dont return project id

### DIFF
--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -135,6 +135,7 @@ DG.ProjectDetector = DG.Handler.extend({
 
                 /* eslint-disable camelcase */
                 return {
+                    id: project.id,
                     code: project.code,
                     minZoom: project.zoom_level.min,
                     maxZoom: project.zoom_level.max,


### PR DESCRIPTION
issue #323 


Пример: 
http://jsfiddle.net/alekzonder/2ay3sdmf/5/