### PR TITLE
Can't scroll page over map with tap false

### DIFF
--- a/src/DGCustomization/skin/basic/less/dg-customization.less
+++ b/src/DGCustomization/skin/basic/less/dg-customization.less
@@ -75,3 +75,8 @@
         transform: scale(1.2, 1.8);
         }
     }
+
+.dg-dragging-false {
+    touch-action: auto;
+    -ms-touch-action: auto;
+}

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -265,3 +265,12 @@ DG.Map.include({
 DG.Map.addInitHook(function () {
     this.on('layeradd layerremove', this._updateTileLayers);
 });
+
+// Set css property touch-action to auto if dragging is false.
+// Need for scrolling page in mobile using our map dom element.
+// todo: I made issue in leaflet https://github.com/Leaflet/Leaflet/issues/4415
+DG.Map.addInitHook(function () {
+    if (this.options.dragging == false && this.options.tap == false) {
+        DG.DomUtil.addClass(this._container, 'dg-dragging-false');
+    }
+});


### PR DESCRIPTION
Нельзя сделать так, чтобы на мобильных устройствах можно было скролить страницу тыкая в карту.

Не помогают даже следующие опции:
```js
var map = DG.map('map', {
    center: [54.98, 82.89],
    zoom: 13,
    dragging: false,
    touchZoom: false,
    scrollWheelZoom: false,
    doubleClickZoom: false,
    tap: false,
    keyboard: false
});
```