### PR TITLE
Search attraction without poi data

### DIFF
--- a/src/DGGeoclicker/src/Controller.js
+++ b/src/DGGeoclicker/src/Controller.js
@@ -55,7 +55,7 @@ DG.Geoclicker.Controller = DG.Class.extend({
             self._lastHandleClickArguments = args;
         }
 
-        if (meta && meta.linked) {
+        if (meta && meta.linked && meta.linked.type != 'sight') {
             if (meta.linked.type != 'branch' && meta.linked.type != 'building') {
                 return;
             }


### PR DESCRIPTION
Достопримечательности теперь тоже пои. А мы ищем только поёвины зданий и фирм.
Поиск по пои вынесен отдельно, т.к. для зданий и фирм, если они есть в пои, требуется всего 1 запрос, а не 2. С достопримечательностями это не работает. 