### PR TITLE
Fix basic package

### DIFF
--- a/gulp/deps/deps.js
+++ b/gulp/deps/deps.js
@@ -181,7 +181,7 @@ var deps = {
     DGProjectDetector: {
         desc: '2GIS project detector module',
         src: ['DGProjectDetector/src/DGProjectDetector.js'],
-        deps: ['DGCore']
+        deps: ['DGCore', 'DGWkt']
     },
 
     DGMeta: {


### PR DESCRIPTION
DGProjectDetector depends on DGWkt. It was the cause of the failing the basic package.