### PR TITLE
Update map setMaxBounds from last leaflet

### DIFF
--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -26,6 +26,27 @@ DG.Map.include({
         }
     },
 
+    // TODO: remove this after update leaflet version higher than
+    // https://github.com/Leaflet/Leaflet/pull/4494/commits/d7fd6b30fd12183e6026c8fd79f7f545c30f193a
+    setMaxBounds: function (bounds) {
+        bounds = DG.latLngBounds(bounds);
+
+        if (!bounds.isValid()) {
+            this.options.maxBounds = null;
+            return this.off('moveend', this._panInsideMaxBounds);
+        } else if (this.options.maxBounds) {
+            this.off('moveend', this._panInsideMaxBounds);
+        }
+
+        this.options.maxBounds = bounds;
+
+        if (this._loaded) {
+            this._panInsideMaxBounds();
+        }
+
+        return this.on('moveend', this._panInsideMaxBounds);
+    },
+
     setView: function (center, zoom, options) {
         this._restrictZoom(center, zoom);
 


### PR DESCRIPTION
Проблема: `map.setMaxBounds()` вызывает ошибку.
В лифлете уже решена https://github.com/Leaflet/Leaflet/pull/4494
Для быстрофикса просто перенёс к нам, в дальнейшем при обновлении лифлета, нужно будет удалить.