### PR TITLE
enable standalone mode only for npm build

### DIFF
--- a/gulp/tasks/buildScripts.js
+++ b/gulp/tasks/buildScripts.js
@@ -30,7 +30,7 @@ gulp.task('buildScripts', ['concatScripts'], function () {
         var bundler = browserify(src, {
             debug: !util.env.release,
             entry: true,
-            standalone: 'DG',
+            standalone: util.env.npm ? 'DG': false,
             cache: {},
             packageCache: {}
         });


### PR DESCRIPTION
В режиме `standalone` АПИ карт не экспортилось в глобальную область, при наличии глобальных переменных RequireJS. Оставил этот режим только для npm-сборки.