### PR TITLE
Remove wrong disabling user select. Fixed #373

### DIFF
--- a/src/DGLabel/skin/basic/less/dg-label.less
+++ b/src/DGLabel/skin/basic/less/dg-label.less
@@ -5,6 +5,7 @@
     max-width: none;
     max-height: none;
     width: 300px;
+    user-select: none;
     }
     .dg-label__content {
         display: inline-block;

--- a/src/DGLabel/src/DGLabel.js
+++ b/src/DGLabel/src/DGLabel.js
@@ -57,7 +57,6 @@ DG.Label = DG.Layer.extend({
         this._el.style.zIndex = this._defaultZIndex + this.options.zIndexOffset;
 
         this._container = DG.DomUtil.create('div', this.options.className + '__content', this._el);
-        DG.DomUtil.disableTextSelection(this._container);
         DG.DomEvent
             .disableClickPropagation(this._el)
             .on(this._container, 'mousewheel', DG.DomEvent.stopPropagation)


### PR DESCRIPTION
Правит https://github.com/2gis/mapsapi/issues/373

Функция `DG.DomUtil.disableTextSelection` не принимает никаких аргументов, и выключает выделение текста на всей странице. Сделал через стили.