### PR TITLE
Don't show empty labels

### DIFF
--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -90,11 +90,13 @@ DG.Poi = DG.Handler.extend({
     _layerEventsListeners : {
         mouseover: function (e) { // (Object)
             this._setCursor('pointer');
-            this._labelHelper
-                .setPosition(e.latlng)
-                .setContent(e.meta.hint)
-                .setZIndexOffset(300);
-            this._map.addLayer(this._labelHelper);
+            if (e.meta.hint && e.meta.hint.length) {
+                this._labelHelper
+                    .setPosition(e.latlng)
+                    .setContent(e.meta.hint)
+                    .setZIndexOffset(300);
+                this._map.addLayer(this._labelHelper);
+            }
             this._map.fire('poihover', {
                 latlng: e.latlng,
                 meta: e.meta


### PR DESCRIPTION
Поправил, чтобы при наведении на парковки не показывались пустые подсказки:
![2016-09-21 18 37 45](https://cloud.githubusercontent.com/assets/3996552/18709475/8be83b40-802a-11e6-8331-cd99afbc9e60.png)
