### PR TITLE
fixed map creation example

### DIFF
--- a/src/doc/ru/quickstart/quickstart.md
+++ b/src/doc/ru/quickstart/quickstart.md
@@ -36,7 +36,7 @@
         var map;
 
         DG.then(function () {
-            map = DG.map('map', {
+            map = new DG.map('map', {
                 center: [54.98, 82.89],
                 zoom: 13
             });


### PR DESCRIPTION
If called without 'new', it throws an error 'this.callInitHooks is not a function'