### PR TITLE
Move prepublish to pub npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node app",
     "test": "gulp test",
     "lint": "gulp lint",
-    "prepublish": "gulp clean && gulp build --npm"
+    "pub": "gulp clean && gulp build --npm && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Вернул `prepublish` на `pub`, т.к. из-за этого сборка происходит каждый раз при прогоне тестов в тревисе и это :rage3: 