### PR TITLE
Change project detection mechanic

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -18,7 +18,7 @@
     "webApiKey": "ruregt3044",
     "webApiVersion": "2.0",
 
-    "regionListFields": "items.bounds,items.zoom_level,items.time_zone,items.code,items.flags,items.country_code,items.domain",
+    "regionListFields": "items.bounds,items.zoom_level,items.time_zone,items.code,items.flags,items.country_code,items.domain,items.default_pos",
     "firmInfoFields": "items.reviews,items.photos,items.links,items.external_content",
     "geoAdditionalFields": "items.geometry.selection,items.links,items.adm_div,items.address,items.floors,items.description",
     "geoclickerCatalogApiKey": "ruregt3044",

--- a/src/DGLocale/test/DGLocaleSpec.js
+++ b/src/DGLocale/test/DGLocaleSpec.js
@@ -43,6 +43,8 @@ describe('DG Locale Module', function () {
 		});
 
 		it('should return default language (ru) if setLang was called with invalid argument: undefined, null, etc', function () {
+			getLangSpy.reset();
+    
 			map.setLang(null);
 			map.getLang();
 

--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -2,10 +2,8 @@ DG.ProjectDetector = DG.Handler.extend({
     initialize: function (map) { // (Object)
         this._map = map;
         this._osmViewport = false;
-        this._project = null;
-        this._noProjectEventFired = false;
+        this._project = undefined;
         this._loadProjectList();
-        this._searchProject();
     },
 
     addHooks: function () {
@@ -54,11 +52,8 @@ DG.ProjectDetector = DG.Handler.extend({
             this._map.attributionControl._update(null, this._osmViewport);
         }
 
-        if (this._project && this._centerInProject(this._project) && this._zoomInProject(this._project)) { return; }
-
-        if (this._project) {
-            this._project = null;
-            this._map.fire('projectleave');
+        if (this._project && this._zoomInProject(this._project) && this._centerInProject(this._project)) {
+            return;
         }
 
         this._searchProject();
@@ -71,7 +66,7 @@ DG.ProjectDetector = DG.Handler.extend({
         }
     },
 
-    _checkProject: function (project) {
+    _checkProjectData: function (project) {
         function check (value) {
             return value !== undefined && value !== null;
         }
@@ -89,8 +84,6 @@ DG.ProjectDetector = DG.Handler.extend({
     },
 
     _loadProjectList: function () {
-        var self = this;
-
         DG.fallbackProjectsList = DG.fallbackProjectsList || [];
 
         if (!DG.projectsList) {
@@ -99,10 +92,12 @@ DG.ProjectDetector = DG.Handler.extend({
         delete DG.fallbackProjectsList;
 
         this._projectList = DG.projectsList
-            .filter(self._checkProject)
+            .filter(this._checkProjectData)
             .map(function (project) {
                 var bound = DG.Wkt.toGeoJSON(project.bounds);
                 var latLngBounds = DG.geoJSON(bound).getBounds();
+                var defaultPos = project.default_pos ? DG.latLng(project.default_pos.lat, project.default_pos.lon) : null;
+
 
                 /* eslint-disable camelcase */
                 return {
@@ -117,45 +112,62 @@ DG.ProjectDetector = DG.Handler.extend({
                     transport: !!project.flags.public_transport,
                     roads: !!project.flags.road_network,
                     country_code: project.country_code,
-                    domain: project.domain
+                    domain: project.domain,
+                    defaultPos: defaultPos
                 };
                 /* eslint-enable camelcase */
             });
     },
 
     _searchProject: function () {
-        var foundProjects = this._projectList
-            .filter(function (project) {
-                return (this._centerInProject(project) && this._zoomInProject(project));
-            }, this);
+        // Вначале отсеиваем регионы по зуму
+        var filteredByZoom = this._projectList.filter(this._zoomInProject, this);
 
-        var loaded = false;
+        // Находим проект в границы которого попадает центр карты
+        var foundProjects = filteredByZoom.filter(this._centerInProject, this);
 
-        try {
-            this._map._checkIfLoaded();
-            loaded = true;
-        } catch (e) {
-            loaded = false;
+        // Если такой проект не найден, то ищем проекты баунд боксы которых пересекаются с экраном
+        if (foundProjects.length === 0) {
+            var mapBounds = this._map.getBounds();
+            foundProjects = filteredByZoom.filter(DG.bind(this._testProjectIntersects, this, mapBounds));
+
+            if (foundProjects.length > 1) {
+                var mapCenter = this._map.getCenter();
+                var neareastProject = foundProjects[0];
+                for (var i = 1; i < foundProjects.length; i++) {
+                    var currentProject = foundProjects[i];
+                    if (currentProject.defaultPos &&
+                        mapCenter.distanceTo(neareastProject.defaultPos) >
+                        mapCenter.distanceTo(currentProject.defaultPos)
+                    ) {
+                        neareastProject = currentProject;
+                    }
+                }
+                foundProjects = [neareastProject];
+            }
         }
 
-        if (loaded && foundProjects.length === 0 && !this._noProjectEventFired) {
-            var self = this;
+        var newProject = foundProjects[0] || null;
+
+        if (this._project === newProject) {
+            return;
+        }
+
+        var self = this;
+
+        if (this._project !== null) {
+            this._project = null;
             setTimeout(function () {
                 self._map.fire('projectleave');
-                self._noProjectEventFired = true;
             }, 1);
         }
 
-        foundProjects.some(function (project) {
-            var self = this;
-
-            this._project = project;
+        if (newProject) {
+            this._project = newProject;
             setTimeout(function () {
-                self._map.fire('projectchange', {'getProject': self.getProject.bind(self)});
+                self._map.fire('projectchange', {getProject: self.getProject.bind(self)});
             }, 1);
-
-            return true;
-        }, this);
+        }
     },
 
     _testProjectIntersects: function (bounds, project) {
@@ -167,11 +179,7 @@ DG.ProjectDetector = DG.Handler.extend({
     },
 
     _centerInProject: function (project, checkMethod) {
-        try {
-            return this.isProjectHere(this._map.getCenter(), project, checkMethod);
-        } catch (e) {
-            return false;
-        }
+        return this.isProjectHere(this._map.getCenter(), project, checkMethod);
     },
 
     _zoomInProject: function (project) {

--- a/src/DGProjectDetector/test/ProjectDetectorInSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorInSpec.js
@@ -1,4 +1,3 @@
-/*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, sinon:false */
 describe('DG.ProjectDetectorIn', function () {
     var map,
         spy,
@@ -412,20 +411,22 @@ describe('DG.ProjectDetectorIn', function () {
     });
 
     describe('#should fire', function () {
-
-        //TODO: uncomment when 'projectchange' event firing become sync
-        /*it('\'projectchange\' event', function () {
-            spy = sinon.spy();
-            map.on('projectchange', spy);
+        it('\'projectchange\' event', function (done) {
+            var onProjectChange = function () {
+                map.off('projectchange', onProjectChange);
+                done();
+            };
+            map.on('projectchange', onProjectChange);
             map.setView(project2, maxZoom);
-            expect(spy.called).to.be.ok();
-        });*/
+        });
 
-        it('\'projectleave\' event', function () {
-            spy = sinon.spy();
-            map.on('projectleave', spy);
+        it('\'projectleave\' event', function (done) {
+            var onProjectLeave = function () {
+                map.off('projectleave', onProjectLeave);
+                done();
+            };
+            map.on('projectleave', onProjectLeave);
             map.setView(desert1, maxZoom);
-            expect(spy.called).to.be.ok();
         });
     });
 });

--- a/src/DGProjectDetector/test/ProjectDetectorInitSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorInitSpec.js
@@ -1,4 +1,3 @@
-/*global describe:false, it:false, expect:false, afterEach:false */
 describe('DG.ProjectDetectorInit', function () {
     var map,
         mapContainer,

--- a/src/DGProjectDetector/test/ProjectDetectorOutOfWorldSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorOutOfWorldSpec.js
@@ -1,4 +1,3 @@
-/*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, sinon:false */
 describe('DG.ProjectDetectorOut', function () {
     var map,
         spy,
@@ -412,20 +411,22 @@ describe('DG.ProjectDetectorOut', function () {
     });
 
     describe('#should fire', function () {
-
-        //TODO: uncomment when 'projectchange' event firing become sync
-        /*it('\'projectchange\' event', function () {
-            spy = sinon.spy();
-            map.on('projectchange', spy);
+        it('\'projectchange\' event', function (done) {
+            var onProjectChange = function () {
+                map.off('projectchange', onProjectChange);
+                done();
+            };
+            map.on('projectchange', onProjectChange);
             map.setView(project2, maxZoom);
-            expect(spy.called).to.be.ok();
-        });*/
+        });
 
-        it('\'projectleave\' event', function () {
-            spy = sinon.spy();
-            map.on('projectleave', spy);
+        it('\'projectleave\' event', function (done) {
+            var onProjectLeave = function () {
+                map.off('projectleave', onProjectLeave);
+                done();
+            };
+            map.on('projectleave', onProjectLeave);
             map.setView(desert1, maxZoom);
-            expect(spy.called).to.be.ok();
         });
     });
 });

--- a/src/DGProjectDetector/test/ProjectDetectorUnderSpec.js
+++ b/src/DGProjectDetector/test/ProjectDetectorUnderSpec.js
@@ -1,4 +1,3 @@
-/*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, sinon:false */
 describe('DG.ProjectDetectorUnder', function () {
     var map,
         spy,
@@ -286,7 +285,7 @@ describe('DG.ProjectDetectorUnder', function () {
 
     });
 
-     describe('#panBy', function () {
+    describe('#panBy', function () {
 
         it('call with viewport size', function () {
             map.setView(project1, 16);
@@ -411,21 +410,22 @@ describe('DG.ProjectDetectorUnder', function () {
     });
 
     describe('#should fire', function () {
-
-        //TODO: uncomment when 'projectchange' event firing become sync
-        /*it('\'projectchange\' event', function () {
-            spy = sinon.spy();
-            map.on('projectchange', spy);
+        it('\'projectchange\' event', function (done) {
+            var onProjectChange = function () {
+                map.off('projectchange', onProjectChange);
+                done();
+            };
+            map.on('projectchange', onProjectChange);
             map.setView(project2, maxZoom);
-            expect(spy.called).to.be.ok();
-        });*/
+        });
 
-        it('\'projectleave\' event', function () {
-            spy = sinon.spy();
-            map.on('projectleave', spy);
-            map.setView(project1, 17);
+        it('\'projectleave\' event', function (done) {
+            var onProjectLeave = function () {
+                map.off('projectleave', onProjectLeave);
+                done();
+            };
+            map.on('projectleave', onProjectLeave);
             map.setView(desert1, maxZoom);
-            expect(spy.called).to.be.ok();
         });
     });
 });

--- a/src/DGTrafficControl/test/TrafficControlSpec.js
+++ b/src/DGTrafficControl/test/TrafficControlSpec.js
@@ -5,7 +5,7 @@ describe('DG.TrafficControl', function() {
 
         centerNsk = [55.017493, 82.819576],
         centerSpb = [59.937706, 30.13249],
-        centerWithoutProject = [54.83391822270635, 80.34439086914064],
+        centerWithoutProject = [55.363990665081126, 77.81307220458986],
 
         mapContainer,
         map,
@@ -146,9 +146,14 @@ describe('DG.TrafficControl', function() {
                 expect(controlParent.className).not.contain(controlParentHiddenClass);
             });
 
-            it('add hide class to control parent element', function () {
+            it('add hide class to control parent element', function (done) {
+                var onProjectLeave = function (ev) {
+                    map.off('projectleave', onProjectLeave);
+                    expect(controlParent.className).to.contain(controlParentHiddenClass);
+                    done();
+                };
+                map.on('projectleave', onProjectLeave);
                 map.setView(centerWithoutProject, 15, {animate: false});
-                expect(controlParent.className).to.contain(controlParentHiddenClass);
             });
 
             it('remove hide class from control parent element', function () {
@@ -173,9 +178,15 @@ describe('DG.TrafficControl', function() {
                 expect(controlParent.className).to.contain(controlParentActiveClass);
             });
 
-            it('add hide class to control parent element', function () {
+            it('add hide class to control parent element', function (done) {
+                var onProjectLeave = function (ev) {
+                    map.off('projectleave', onProjectLeave);
+                    expect(controlParent.className).to.contain(controlParentHiddenClass);
+                    done();
+                };
+                map.on('projectleave', onProjectLeave);
+
                 map.setView(centerWithoutProject, 15, {animate: false});
-                expect(controlParent.className).to.contain(controlParentHiddenClass);
             });
 
             it('remove hide class from control parent element', function () {

--- a/src/doc/ru/examples/events.md
+++ b/src/doc/ru/examples/events.md
@@ -109,9 +109,8 @@
 
         // подписываемся на событие изменения текущего проекта 2GIS
         map.on('projectchange', function(e) {
-            var bounds = e.getProject().latLngBounds;
-
-            currentProjectBound = DG.rectangle(bounds, {
+            var bounds = e.getProject().bound;
+            currentProjectBound = DG.geoJSON(bounds, {
                 color:"#f03",
                 weight:1
             }).addTo(map);
@@ -145,8 +144,8 @@
 
                     // подписываемся на событие изменения текущего проекта 2GIS
                     map.on('projectchange', function(e) {
-                        var bounds = e.getProject().latLngBounds;
-                        currentProjectBound = DG.rectangle(bounds, {
+                        var bounds = e.getProject().bound;
+                        currentProjectBound = DG.geoJSON(bounds, {
                             color:"#f03",
                             weight:1
                         }).addTo(map);


### PR DESCRIPTION
Поменял механику определения проекта, теперь используем следующие способы в порядке приоритета:
1. Ищем проект в который попадает центр карты
2. Ищем проект попавший во вьюпорт
3. Если несколько проектов попали во вьюпорт, то выбираем тот `default_pos` которого ближе всех к центру карты.

Также выпилил вызов поиска региона прямо конструкторе `ProjectDetector`, поскольку он создается через инит хуки, а после этого все равно вызывается `setView`. Это позволило убрать костыли с `try { } catch (e) { }`.

Также `projectleave` теперь вызывается всегда асинхронно, также как `projectchange`. Поэтому некоторые тесты сделал асинхронными через `done` (есть вероятность, что иногда они будут зависать навечно).
