### PR TITLE
Fix links doc

### DIFF
--- a/src/doc/ru/manual/controls.md
+++ b/src/doc/ru/manual/controls.md
@@ -68,11 +68,11 @@
     </tbody>
 </table>
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.Attribution
 
@@ -123,7 +123,7 @@
     </tbody>
 </table>
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
@@ -163,7 +163,7 @@
     </tbody>
 </table>
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.Scale
 
@@ -232,11 +232,11 @@
     </tbody>
 </table>
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.Ruler
 
@@ -266,11 +266,11 @@
 
 #### Опции
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.Traffic
 
@@ -300,11 +300,11 @@
 
 #### Опции
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.Fullscreen
 
@@ -336,11 +336,11 @@
 
 #### Опции
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 ### DG.Control.LocationControl
 
@@ -414,8 +414,8 @@
     </tbody>
 </table>
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
 
 #### Методы
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgcontrol">Control</a> <!-- TODO: include options -->

--- a/src/doc/ru/manual/dom-utils.md
+++ b/src/doc/ru/manual/dom-utils.md
@@ -469,7 +469,7 @@
     </tbody>
 </table>
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
 
 ### DG.Draggable
 
@@ -559,4 +559,4 @@
     </tbody>
 </table>
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->

--- a/src/doc/ru/manual/other-layers.md
+++ b/src/doc/ru/manual/other-layers.md
@@ -33,11 +33,11 @@
 
 #### Опции
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
 
 #### События
 
-События, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
+События, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
 
 #### Методы
 
@@ -149,9 +149,9 @@
     </tbody>
 </table>
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
 
 ### DG.FeatureGroup
 
@@ -184,11 +184,11 @@
 
 #### Опции
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
 
 #### События
 
-События, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
+События, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
 
 #### Методы
 
@@ -234,9 +234,9 @@
 
 Методы, унаследованные от <a href="#dglayergroup">LayerGroup</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
 
 ### DG.GeoJSON
 
@@ -344,11 +344,11 @@ GeoJSON и отобразить их на карте. Расширяет <a href
     </tbody>
 </table>
 
-Опции, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
+Опции, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include options -->
 
 #### События
 
-События, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
+События, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
 
 #### Методы
 
@@ -356,9 +356,9 @@ GeoJSON и отобразить их на карте. Расширяет <a href
 
 Методы, унаследованные от <a href="#dglayergroup">LayerGroup</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
 
 #### Статические функции
 
@@ -633,7 +633,7 @@ GeoJSON и отобразить их на карте. Расширяет <a href
     </tbody>
 </table>
 
-События, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
+События, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include events -->
 
 #### Методы
 
@@ -739,6 +739,6 @@ GeoJSON и отобразить их на карте. Расширяет <a href
     </tbody>
 </table>
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dglayer">Layer</a> <!-- TODO: include methods -->
 
-Методы, унаследованные от <a href="/doc/maps/en/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->
+Методы, унаследованные от <a href="/doc/maps/ru/manual/base-classes#dgevented">Evented</a> <!-- TODO: include methods -->


### PR DESCRIPTION
Все ссылки на базовые классы были сломаны, т.к. почему-то вели на английскую документацию.

@stellarator так было задумано или недоглядели? И что означает `<!-- TODO: include methods -->`?
