### PR TITLE
Fix popup offset

### DIFF
--- a/src/DGPopup/skin/basic/less/leaflet.less
+++ b/src/DGPopup/skin/basic/less/leaflet.less
@@ -1,3 +1,7 @@
+.leaflet-popup {
+    margin-bottom: 0;
+    }
+
 .leaflet-popup-tip-container {
     height: 0;
     }


### PR DESCRIPTION
После обновления лифлета у `.leaflet-popup` добавилось свойство `margin-bottom: 20px;`, нам оно не нужно.