### PR TITLE
Support retina tile server

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -32,13 +32,17 @@
     "baseUrl": "//maps.api.2gis.ru/2.0",
 
     "tileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
+    "retinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
 
     "trafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
+    "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
     "trafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/{timestampString}",
+    "retinaTrafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/{timestampString}",
     "trafficTimestampServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/speed/time/",
     "trafficScoreServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/score/0/",
 
     "poiMetaServer": "//tile{s}.maps.2gis.com/?x={x}&y={y}&z={z}&v=1&type=poi",
+    "retinaPoiMetaServer": "//tile{s}.maps.2gis.com/?x={x}&y={y}&z={z}&v=1&type=poi",
 
     "webApiServer": "//catalog.api.2gis.ru",
 

--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -13,7 +13,7 @@ DG.Map.addInitHook(function () {
         }
     });
 
-    var tileUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer;
+    var tileUrl = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer);
 
     this.baseLayer = new BaseLayer(tileUrl, {
         subdomains: '0123',

--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -13,7 +13,9 @@ DG.Map.addInitHook(function () {
         }
     });
 
-    this.baseLayer = new BaseLayer(DG.config.protocol + DG.config.tileServer, {
+    var tileUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer;
+
+    this.baseLayer = new BaseLayer(tileUrl, {
         subdomains: '0123',
         errorTileUrl: this.getLang() === 'ru' ? errorRuUrl : errorUrl,
         detectRetina: DG.config.detectRetina,

--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -11,7 +11,10 @@ DG.Poi = DG.Handler.extend({
     initialize: function (map, options) { // (Object)
         this._map = map;
         DG.Util.setOptions(this, options);
-        this._metaLayer = DG.Meta.layer(DG.config.protocol + DG.config.poiMetaServer, {
+
+        var url = DG.config.protocol + DG.Browser.retina ? DG.config.retinaPoiMetaServer : DG.config.poiMetaServer;
+
+        this._metaLayer = DG.Meta.layer(url, {
             minZoom: DG.config.poiLayerMinZoom,
             maxNativeZoom: 19,
             detectRetina: DG.config.detectRetina,

--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -12,7 +12,7 @@ DG.Poi = DG.Handler.extend({
         this._map = map;
         DG.Util.setOptions(this, options);
 
-        var url = DG.config.protocol + DG.Browser.retina ? DG.config.retinaPoiMetaServer : DG.config.poiMetaServer;
+        var url = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaPoiMetaServer : DG.config.poiMetaServer);
 
         this._metaLayer = DG.Meta.layer(url, {
             minZoom: DG.config.poiLayerMinZoom,

--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -9,8 +9,8 @@ DG.Traffic = DG.TileLayer.extend({
     },
 
     initialize: function (options) {
-        this._tileUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTrafficTileServer : DG.config.trafficTileServer;
-        this._metaUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTrafficMetaServer : DG.config.trafficMetaServer;
+        this._tileUrl = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaTrafficTileServer : DG.config.trafficTileServer);
+        this._metaUrl = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaTrafficMetaServer : DG.config.trafficMetaServer);
         this._timeUrl = DG.config.protocol + DG.config.trafficTimestampServer;
         this._updateInterval = DG.config.trafficLayerUpdateInterval;
 

--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -9,8 +9,8 @@ DG.Traffic = DG.TileLayer.extend({
     },
 
     initialize: function (options) {
-        this._tileUrl = DG.config.protocol + DG.config.trafficTileServer;
-        this._metaUrl = DG.config.protocol + DG.config.trafficMetaServer;
+        this._tileUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTrafficTileServer : DG.config.trafficTileServer;
+        this._metaUrl = DG.config.protocol + DG.Browser.retina ? DG.config.retinaTrafficMetaServer : DG.config.trafficMetaServer;
         this._timeUrl = DG.config.protocol + DG.config.trafficTimestampServer;
         this._updateInterval = DG.config.trafficLayerUpdateInterval;
 


### PR DESCRIPTION
Поддержал ретину для:

- тайлов
- пои
- трафика

Поле `detectRetina` в конфиге сохранил, ретинистые урлы сейчас повторяют обычные. 
Видимо, когда ретина тайлы окажутся на бою, нужно будет еще раз поменять урлы и выпилить поле `detectRetina`.