### PR TITLE
Remove no-touch class

### DIFF
--- a/src/DGCore/src/DGCore.js
+++ b/src/DGCore/src/DGCore.js
@@ -72,11 +72,4 @@ DG.Map.include({
     }
 });
 
-// Apply class to map container for detect when we dont need hover effects
-DG.Map.addInitHook(function () {
-    if (!DG.Browser.touch) {
-        DG.DomUtil.addClass(this._container, 'no-touch');
-    }
-});
-
 module.exports = DG;

--- a/src/DGCore/src/DGCore.js
+++ b/src/DGCore/src/DGCore.js
@@ -72,4 +72,11 @@ DG.Map.include({
     }
 });
 
+// Apply class to map container for detect when we dont need hover effects
+DG.Map.addInitHook(function () {
+    if (!DG.Browser.touch) {
+        DG.DomUtil.addClass(this._container, 'no-touch');
+    }
+});
+
 module.exports = DG;

--- a/src/DGCustomization/skin/basic/less/dg-customization.less
+++ b/src/DGCustomization/skin/basic/less/dg-customization.less
@@ -10,11 +10,13 @@
         background-image: inherit;
         background-size: contain;
         background-repeat: no-repeat;
-        transition: opacity ease-in-out .2s, transform ease-in-out .2s;
+        transition:
+            opacity ease-in-out .2s,
+            transform ease-in-out .2s;
         transform: scale(1, 1);
         transform-origin: 50% 100%;
+        }
     }
-}
 
 .dg-customization__marker_type_mushroom {
     .notRepeatableBgWithSizes('DGCustomization__marker', true);
@@ -23,33 +25,30 @@
 
     &:focus {
         outline: 0;
-    }
+        }
 
-    &:hover {
+    .no-touch &:hover {
         .notRepeatableBg('DGCustomization__markerHover', true);
-    }
+        }
 
-    &:active {
+    &:active,
+    .no-touch &:active {
         .notRepeatableBg('DGCustomization__markerActive', true);
+        }
     }
-}
 
 @keyframes dg-customization__show-marker {
-    from {
-        opacity: 0;
+    from { opacity: 0; }
+    to { opacity: 1; }
     }
-    to {
-        opacity: 1;
-    }
-}
 
 .dg-customization__marker_appear {
     background-position: 999px;
 
     &:before {
         content: '';
+        }
     }
-}
 
 .dg-customization__marker_disappear {
     background-position: 999px;
@@ -61,21 +60,21 @@
         opacity: 0;
         transform: scale(1.2, 1.8);
         animation: dg-customization__marker-to-callout .2s;
+        }
     }
-}
 
 @keyframes dg-customization__marker-to-callout {
     0% {
         visibility: visible;
         opacity: 1;
         transform: scale(1, 1);
-    }
+        }
     100% {
         visibility: visible;
         opacity: 0;
         transform: scale(1.2, 1.8);
+        }
     }
-}
 
 .dg-dragging-false {
     touch-action: auto;
@@ -84,5 +83,5 @@
 
 .leaflet-image-layer,
 .leaflet-tile-container {
-    pointer-events: auto;
+	pointer-events: auto;
 }

--- a/src/DGCustomization/skin/basic/less/dg-customization.less
+++ b/src/DGCustomization/skin/basic/less/dg-customization.less
@@ -27,12 +27,11 @@
         outline: 0;
         }
 
-    .no-touch &:hover {
+    &:hover {
         .notRepeatableBg('DGCustomization__markerHover', true);
         }
 
-    &:active,
-    .no-touch &:active {
+    &:active {
         .notRepeatableBg('DGCustomization__markerActive', true);
         }
     }

--- a/src/DGCustomization/skin/basic/less/dg-customization.less
+++ b/src/DGCustomization/skin/basic/less/dg-customization.less
@@ -10,13 +10,11 @@
         background-image: inherit;
         background-size: contain;
         background-repeat: no-repeat;
-        transition:
-            opacity ease-in-out .2s,
-            transform ease-in-out .2s;
+        transition: opacity ease-in-out .2s, transform ease-in-out .2s;
         transform: scale(1, 1);
         transform-origin: 50% 100%;
-        }
     }
+}
 
 .dg-customization__marker_type_mushroom {
     .notRepeatableBgWithSizes('DGCustomization__marker', true);
@@ -25,30 +23,33 @@
 
     &:focus {
         outline: 0;
-        }
-
-    .no-touch &:hover {
-        .notRepeatableBg('DGCustomization__markerHover', true);
-        }
-
-    &:active,
-    .no-touch &:active {
-        .notRepeatableBg('DGCustomization__markerActive', true);
-        }
     }
+
+    &:hover {
+        .notRepeatableBg('DGCustomization__markerHover', true);
+    }
+
+    &:active {
+        .notRepeatableBg('DGCustomization__markerActive', true);
+    }
+}
 
 @keyframes dg-customization__show-marker {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+        opacity: 0;
     }
+    to {
+        opacity: 1;
+    }
+}
 
 .dg-customization__marker_appear {
     background-position: 999px;
 
     &:before {
         content: '';
-        }
     }
+}
 
 .dg-customization__marker_disappear {
     background-position: 999px;
@@ -60,21 +61,21 @@
         opacity: 0;
         transform: scale(1.2, 1.8);
         animation: dg-customization__marker-to-callout .2s;
-        }
     }
+}
 
 @keyframes dg-customization__marker-to-callout {
     0% {
         visibility: visible;
         opacity: 1;
         transform: scale(1, 1);
-        }
+    }
     100% {
         visibility: visible;
         opacity: 0;
         transform: scale(1.2, 1.8);
-        }
     }
+}
 
 .dg-dragging-false {
     touch-action: auto;
@@ -83,5 +84,5 @@
 
 .leaflet-image-layer,
 .leaflet-tile-container {
-	pointer-events: auto;
+    pointer-events: auto;
 }

--- a/src/DGFullScreen/skin/basic/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/basic/less/dg-control-round.less
@@ -10,7 +10,7 @@
 		}
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconEnabled');
         }

--- a/src/DGFullScreen/skin/basic/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/basic/less/dg-control-round.less
@@ -1,17 +1,17 @@
 .dg-control-round__icon_name_fullscreen {
-    &:after {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        margin: auto;
-        content: '';
-    }
+	&:after {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		margin: auto;
+		content: '';
+		}
 
     .dg-control-round__icon_state_active&:after,
-    .dg-control-round__icon_state_active&:hover:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconEnabled');
+        }
     }
-}

--- a/src/DGFullScreen/skin/basic/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/basic/less/dg-control-round.less
@@ -1,17 +1,17 @@
 .dg-control-round__icon_name_fullscreen {
-	&:after {
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		margin: auto;
-		content: '';
-		}
+    &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        content: '';
+    }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconEnabled');
-        }
     }
+}

--- a/src/DGFullScreen/skin/dark/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/dark/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_dark');
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_dark');
-        }
     }
+}

--- a/src/DGFullScreen/skin/dark/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/dark/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_dark');
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_dark');
+        }
     }
-}

--- a/src/DGFullScreen/skin/dark/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/dark/less/dg-control-round.less
@@ -3,7 +3,7 @@
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_dark');
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_dark');
         }

--- a/src/DGFullScreen/skin/light/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/light/less/dg-control-round.less
@@ -3,7 +3,7 @@
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_light');
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_light');
         }

--- a/src/DGFullScreen/skin/light/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/light/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_light');
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_light');
+        }
     }
-}

--- a/src/DGFullScreen/skin/light/less/dg-control-round.less
+++ b/src/DGFullScreen/skin/light/less/dg-control-round.less
@@ -1,10 +1,10 @@
 .dg-control-round__icon_name_fullscreen {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__fullscreenIcon_light');
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__fullscreenIconHover_light');
-        }
     }
+}

--- a/src/DGGeoclicker/skin/basic/less/dg-link.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-link.less
@@ -3,17 +3,17 @@
     background-position: 0 95%;
     background-size: 10px 1px;
     background-repeat: repeat-x;
-    }
+}
 
 .dg-link_type_local {
     background: linear-gradient(to right, #99ccdd, #99ccdd 50%, transparent 50%);
 
-    .no-touch &:hover {
+    &:hover {
         background: linear-gradient(to right, #99bbcc, #99bbcc 50%, transparent 50%);
-        }
     }
+}
 
 .dg-link.dg-link_type_local,
 .dg-link.dg-link_type_local:hover {
     background-size: 6px 1px;
-    }
+}

--- a/src/DGGeoclicker/skin/basic/less/dg-link.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-link.less
@@ -3,17 +3,17 @@
     background-position: 0 95%;
     background-size: 10px 1px;
     background-repeat: repeat-x;
-}
+    }
 
 .dg-link_type_local {
     background: linear-gradient(to right, #99ccdd, #99ccdd 50%, transparent 50%);
 
-    &:hover {
+    .no-touch &:hover {
         background: linear-gradient(to right, #99bbcc, #99bbcc 50%, transparent 50%);
+        }
     }
-}
 
 .dg-link.dg-link_type_local,
 .dg-link.dg-link_type_local:hover {
     background-size: 6px 1px;
-}
+    }

--- a/src/DGGeoclicker/skin/basic/less/dg-link.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-link.less
@@ -8,7 +8,7 @@
 .dg-link_type_local {
     background: linear-gradient(to right, #99ccdd, #99ccdd 50%, transparent 50%);
 
-    .no-touch &:hover {
+    &:hover {
         background: linear-gradient(to right, #99bbcc, #99bbcc 50%, transparent 50%);
         }
     }

--- a/src/DGGeoclicker/skin/basic/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-popup.less
@@ -2,65 +2,62 @@
     display: table;
     margin-top: 10px;
     width: 100%;
-}
-
-.dg-popup__footer-button-wrapper {
-    display: table-cell;
-}
-
-.dg-popup__footer-button {
-    position: relative;
-    display: inline-block;
-    box-sizing: border-box;
-    margin-left: 5%;
-    width: 95%;
-    border-radius: 2px;
-    text-align: center;
-    text-decoration: none;
-    font: 12px/24px Arial, sans-serif;
-    cursor: pointer;
-    transition: all .1s;
-
-    .dg-popup__footer-button-wrapper:first-child & {
-        margin: 0;
-        width: 100%;
     }
+    .dg-popup__footer-button-wrapper {
+        display: table-cell;
+        }
+        .dg-popup__footer-button {
+            position: relative;
+            display: inline-block;
+            box-sizing: border-box;
+            margin-left: 5%;
+            width: 95%;
+            border-radius: 2px;
+            text-align: center;
+            text-decoration: none;
+            font: 12px/24px Arial, sans-serif;
+            cursor: pointer;
+            transition: all .1s;
 
-    &:hover {
-        transition: all .2s; /* @TODO: all? */
-    }
-}
+            .dg-popup__footer-button-wrapper:first-child & {
+                margin: 0;
+                width: 100%;
+                }
 
-.dg-popup__footer-icon-button:before {
-    display: inline-block;
-    margin: -2px 5px 0 0;
-    width: 12px;
-    height: 12px;
-    background-size: contain;
-    background-repeat: no-repeat;
-    content: '';
-    vertical-align: middle;
-}
+            .no-touch &:hover {
+                transition: all .2s; /* @TODO: all? */
+                }
+            }
+            .dg-popup__footer-icon-button:before {
+                display: inline-block;
+                margin: -2px 5px 0 0;
+                width: 12px;
+                height: 12px;
+                background-size: contain;
+                background-repeat: no-repeat;
+                content: '';
+                vertical-align: middle;
+                }
 
-.dg-popup__button_name_goto:before {
-    width: 20px;
-    height: 7px;
-}
+    .dg-popup__button_name_goto:before {
+        width: 20px;
+        height: 7px;
+        }
 
-.dg-popup__button_name_firm-card-back:before {
-    width: 9px;
-    height: 6px;
-}
+    .dg-popup__button_name_firm-card-back:before {
+        width: 9px;
+        height: 6px;
+        }
 
-.dg-popup__button_name_firm-list-back:before {
-    width: 9px;
-    height: 6px;
-}
+    .dg-popup__button_name_firm-list-back:before {
+        width: 9px;
+        height: 6px;
+        }
 
-.dg-popup__button_name_back:before {
-    width: 9px;
-    height: 6px;
-}
+    .dg-popup__button_name_back:before {
+        width: 9px;
+        height: 6px;
+        }
 
 .dg-popup__show-less-house-link {
     position: relative;
@@ -70,82 +67,78 @@
     text-decoration: none;
     font-size: 12px;
     line-height: 24px;
-}
+    }
 
 .dg-popup__header-links {
     margin: 8px 18px 0 0;
-}
+    }
 
 .dg-popup__header-title_for_firmcard {
     position: relative;
     overflow: hidden;
     max-height: 3.4em;
-}
-
-.dg-popup__header-teaser {
-    display: -webkit-box;
-    height: 3.3em;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-}
-
-.dg-popup__header-title {
-    display: block;
-    white-space: normal;
-    font: 22px/24px 'Arial narrow', Arial, sans-serif;
-}
-
-.dg-popup__header-link {
-    display: inline-block;
-    margin-left: 2.6em;
-    vertical-align: middle;
-    white-space: nowrap;
-
-    &:first-child {
-        margin-left: 1.2em;
     }
-}
+    .dg-popup__header-teaser {
+        display: -webkit-box;
+        height: 3.3em;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        }
 
-.dg-popup__rating {
-    display: inline-block;
-    margin: 0 .4em 3px 0;
-    width: 70px;
-    height: 14px;
-    vertical-align: middle;
-}
+    .dg-popup__header-title {
+        display: block;
+        white-space: normal;
+        font: 22px/24px 'Arial narrow', Arial, sans-serif;
+        }
+        .dg-popup__header-link {
+            display: inline-block;
+            margin-left: 2.6em;
+            vertical-align: middle;
+            white-space: nowrap;
 
-.dg-popup__rating-stars {
-    .repeatableBg('DGPopup__ratingStar');
-    float: left;
-    height: 100%;
-}
+            &:first-child {
+                margin-left: 1.2em;
+                }
+            }
 
-.dg-popup__link {
-    position: relative;
-    background-position: center bottom;
-    background-size: 10px 1px;
-    background-repeat: repeat-x;
-    text-decoration: none;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
+    .dg-popup__rating {
+        display: inline-block;
+        margin: 0 .4em 3px 0;
+        width: 70px;
+        height: 14px;
+        vertical-align: middle;
+        }
+        .dg-popup__rating-stars {
+            .repeatableBg('DGPopup__ratingStar');
+            float: left;
+            height: 100%;
+            }
 
-.dg-popup__link_type_flamp_reviews {
-    margin-left: .1em;
-}
+        .dg-popup__link {
+            position: relative;
+            background-position: center bottom;
+            background-size: 10px 1px;
+            background-repeat: repeat-x;
+            text-decoration: none;
+            -webkit-tap-highlight-color:rgba(0,0,0,0);
+            }
 
-.dg-popup__link_type_photos:before {
-    position: absolute;
-    top: 2px;
-    left: -18px;
-    display: inherit;
-    content: '';
-}
+        .dg-popup__link_type_flamp_reviews {
+            margin-left: .1em;
+            }
+            .dg-popup__link_type_photos:before {
+                position: absolute;
+                top: 2px;
+                left: -18px;
+                display: inherit;
+                content: '';
+                }
 
-.dg-popup__link_type_booklet:before {
-    .notRepeatableBgWithSizes('DGPopup__bookletLinkIcon');
-    position: absolute;
-    top: 2px;
-    left: -18px;
-    display: inherit;
-    content: '';
-}
+            .dg-popup__link_type_booklet:before {
+                .notRepeatableBgWithSizes('DGPopup__bookletLinkIcon');
+                position: absolute;
+                top: 2px;
+                left: -18px;
+                display: inherit;
+                content: '';
+                }

--- a/src/DGGeoclicker/skin/basic/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-popup.less
@@ -24,7 +24,7 @@
                 width: 100%;
                 }
 
-            .no-touch &:hover {
+            &:hover {
                 transition: all .2s; /* @TODO: all? */
                 }
             }

--- a/src/DGGeoclicker/skin/basic/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/basic/less/dg-popup.less
@@ -2,62 +2,65 @@
     display: table;
     margin-top: 10px;
     width: 100%;
+}
+
+.dg-popup__footer-button-wrapper {
+    display: table-cell;
+}
+
+.dg-popup__footer-button {
+    position: relative;
+    display: inline-block;
+    box-sizing: border-box;
+    margin-left: 5%;
+    width: 95%;
+    border-radius: 2px;
+    text-align: center;
+    text-decoration: none;
+    font: 12px/24px Arial, sans-serif;
+    cursor: pointer;
+    transition: all .1s;
+
+    .dg-popup__footer-button-wrapper:first-child & {
+        margin: 0;
+        width: 100%;
     }
-    .dg-popup__footer-button-wrapper {
-        display: table-cell;
-        }
-        .dg-popup__footer-button {
-            position: relative;
-            display: inline-block;
-            box-sizing: border-box;
-            margin-left: 5%;
-            width: 95%;
-            border-radius: 2px;
-            text-align: center;
-            text-decoration: none;
-            font: 12px/24px Arial, sans-serif;
-            cursor: pointer;
-            transition: all .1s;
 
-            .dg-popup__footer-button-wrapper:first-child & {
-                margin: 0;
-                width: 100%;
-                }
+    &:hover {
+        transition: all .2s; /* @TODO: all? */
+    }
+}
 
-            .no-touch &:hover {
-                transition: all .2s; /* @TODO: all? */
-                }
-            }
-            .dg-popup__footer-icon-button:before {
-                display: inline-block;
-                margin: -2px 5px 0 0;
-                width: 12px;
-                height: 12px;
-                background-size: contain;
-                background-repeat: no-repeat;
-                content: '';
-                vertical-align: middle;
-                }
+.dg-popup__footer-icon-button:before {
+    display: inline-block;
+    margin: -2px 5px 0 0;
+    width: 12px;
+    height: 12px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    content: '';
+    vertical-align: middle;
+}
 
-    .dg-popup__button_name_goto:before {
-        width: 20px;
-        height: 7px;
-        }
+.dg-popup__button_name_goto:before {
+    width: 20px;
+    height: 7px;
+}
 
-    .dg-popup__button_name_firm-card-back:before {
-        width: 9px;
-        height: 6px;
-        }
+.dg-popup__button_name_firm-card-back:before {
+    width: 9px;
+    height: 6px;
+}
 
-    .dg-popup__button_name_firm-list-back:before {
-        width: 9px;
-        height: 6px;
-        }
+.dg-popup__button_name_firm-list-back:before {
+    width: 9px;
+    height: 6px;
+}
 
-    .dg-popup__button_name_back:before {
-        width: 9px;
-        height: 6px;
-        }
+.dg-popup__button_name_back:before {
+    width: 9px;
+    height: 6px;
+}
 
 .dg-popup__show-less-house-link {
     position: relative;
@@ -67,78 +70,82 @@
     text-decoration: none;
     font-size: 12px;
     line-height: 24px;
-    }
+}
 
 .dg-popup__header-links {
     margin: 8px 18px 0 0;
-    }
+}
 
 .dg-popup__header-title_for_firmcard {
     position: relative;
     overflow: hidden;
     max-height: 3.4em;
+}
+
+.dg-popup__header-teaser {
+    display: -webkit-box;
+    height: 3.3em;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+
+.dg-popup__header-title {
+    display: block;
+    white-space: normal;
+    font: 22px/24px 'Arial narrow', Arial, sans-serif;
+}
+
+.dg-popup__header-link {
+    display: inline-block;
+    margin-left: 2.6em;
+    vertical-align: middle;
+    white-space: nowrap;
+
+    &:first-child {
+        margin-left: 1.2em;
     }
-    .dg-popup__header-teaser {
-        display: -webkit-box;
-        height: 3.3em;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-        }
+}
 
-    .dg-popup__header-title {
-        display: block;
-        white-space: normal;
-        font: 22px/24px 'Arial narrow', Arial, sans-serif;
-        }
-        .dg-popup__header-link {
-            display: inline-block;
-            margin-left: 2.6em;
-            vertical-align: middle;
-            white-space: nowrap;
+.dg-popup__rating {
+    display: inline-block;
+    margin: 0 .4em 3px 0;
+    width: 70px;
+    height: 14px;
+    vertical-align: middle;
+}
 
-            &:first-child {
-                margin-left: 1.2em;
-                }
-            }
+.dg-popup__rating-stars {
+    .repeatableBg('DGPopup__ratingStar');
+    float: left;
+    height: 100%;
+}
 
-    .dg-popup__rating {
-        display: inline-block;
-        margin: 0 .4em 3px 0;
-        width: 70px;
-        height: 14px;
-        vertical-align: middle;
-        }
-        .dg-popup__rating-stars {
-            .repeatableBg('DGPopup__ratingStar');
-            float: left;
-            height: 100%;
-            }
+.dg-popup__link {
+    position: relative;
+    background-position: center bottom;
+    background-size: 10px 1px;
+    background-repeat: repeat-x;
+    text-decoration: none;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
 
-        .dg-popup__link {
-            position: relative;
-            background-position: center bottom;
-            background-size: 10px 1px;
-            background-repeat: repeat-x;
-            text-decoration: none;
-            -webkit-tap-highlight-color:rgba(0,0,0,0);
-            }
+.dg-popup__link_type_flamp_reviews {
+    margin-left: .1em;
+}
 
-        .dg-popup__link_type_flamp_reviews {
-            margin-left: .1em;
-            }
-            .dg-popup__link_type_photos:before {
-                position: absolute;
-                top: 2px;
-                left: -18px;
-                display: inherit;
-                content: '';
-                }
+.dg-popup__link_type_photos:before {
+    position: absolute;
+    top: 2px;
+    left: -18px;
+    display: inherit;
+    content: '';
+}
 
-            .dg-popup__link_type_booklet:before {
-                .notRepeatableBgWithSizes('DGPopup__bookletLinkIcon');
-                position: absolute;
-                top: 2px;
-                left: -18px;
-                display: inherit;
-                content: '';
-                }
+.dg-popup__link_type_booklet:before {
+    .notRepeatableBgWithSizes('DGPopup__bookletLinkIcon');
+    position: absolute;
+    top: 2px;
+    left: -18px;
+    display: inherit;
+    content: '';
+}

--- a/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
@@ -1,41 +1,41 @@
+
 .dg-firm-card__link a {
-    background-image: linear-gradient(to right, rgba(255, 230, 170, .3), rgba(255, 230, 170, .3) 100%);
+    background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
     color: #ffe6aa;
 
-    &:hover {
-        background-image: linear-gradient(to right, rgba(153, 204, 221, .3), rgba(153, 204, 221, .3) 100%);
+    .no-touch &:hover {
+        background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
         color: #9cd;
+        }
     }
-}
 
 .dg-firm-card__comment {
     color: #aaa;
-}
+    }
 
 .dg-firm-card__rubrics {
     color: #aaa;
-}
-
-.dg-firm-card__rubrics-list-item:after {
-    color: #6e6964;
-}
+    }
+    .dg-firm-card__rubrics-list-item:after {
+        color: #6e6964;
+        }
 
 .dg-firm-card__aa-list-item:after {
     color: #e6e6e6;
-}
+    }
 
 .dg-firm-card__address:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_dark');
-}
+    }
 
 .dg-firm-card__phone:before {
     .notRepeatableBgWithSizes('DGFirmCard__phoneIcon_dark');
-}
+    }
 
 .dg-firm-card__site:before {
     .notRepeatableBgWithSizes('DGFirmCard__siteIcon_dark');
-}
+    }
 
 .dg-firm-card__email:before {
     .notRepeatableBgWithSizes('DGFirmCard__mailIcon_dark');
-}
+    }

--- a/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
@@ -1,41 +1,41 @@
-
 .dg-firm-card__link a {
-    background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
+    background-image: linear-gradient(to right, rgba(255, 230, 170, .3), rgba(255, 230, 170, .3) 100%);
     color: #ffe6aa;
 
-    .no-touch &:hover {
-        background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
+    &:hover {
+        background-image: linear-gradient(to right, rgba(153, 204, 221, .3), rgba(153, 204, 221, .3) 100%);
         color: #9cd;
-        }
     }
+}
 
 .dg-firm-card__comment {
     color: #aaa;
-    }
+}
 
 .dg-firm-card__rubrics {
     color: #aaa;
-    }
-    .dg-firm-card__rubrics-list-item:after {
-        color: #6e6964;
-        }
+}
+
+.dg-firm-card__rubrics-list-item:after {
+    color: #6e6964;
+}
 
 .dg-firm-card__aa-list-item:after {
     color: #e6e6e6;
-    }
+}
 
 .dg-firm-card__address:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_dark');
-    }
+}
 
 .dg-firm-card__phone:before {
     .notRepeatableBgWithSizes('DGFirmCard__phoneIcon_dark');
-    }
+}
 
 .dg-firm-card__site:before {
     .notRepeatableBgWithSizes('DGFirmCard__siteIcon_dark');
-    }
+}
 
 .dg-firm-card__email:before {
     .notRepeatableBgWithSizes('DGFirmCard__mailIcon_dark');
-    }
+}

--- a/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-firm-card.less
@@ -3,7 +3,7 @@
     background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
     color: #ffe6aa;
 
-    .no-touch &:hover {
+    &:hover {
         background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
         color: #9cd;
         }

--- a/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
@@ -1,38 +1,39 @@
+
 .dg-map-geoclicker__address-header:first-child:before,
 .dg-map-geoclicker__address-drilldown:first-child:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_dark');
-}
+    }
 
 .dg-map-geoclicker__purpose {
     &:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purpose_dark');
-    }
+        }
 
     &_type_street:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeStreet_dark');
-    }
+        }
 
     &_type_sight:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSight_dark');
-    }
+        }
 
     &_type_settlement:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSettlement_dark');
+        }
     }
-}
 
 a.dg-map-geoclicker__show-more-sights-link {
     color: #ffe6aa;
 
-    &:hover {
+    .no-touch &:hover {
         color: #9cd;
-    }
+        }
 
     &:after {
         .notRepeatableBg('DGGeoclicker__arrowLeft_dark');
+        }
     }
-}
 
 .dg-map-geoclicker__drilldown {
     color: #aaa;
-}
+    }

--- a/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
@@ -1,39 +1,38 @@
-
 .dg-map-geoclicker__address-header:first-child:before,
 .dg-map-geoclicker__address-drilldown:first-child:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_dark');
-    }
+}
 
 .dg-map-geoclicker__purpose {
     &:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purpose_dark');
-        }
+    }
 
     &_type_street:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeStreet_dark');
-        }
+    }
 
     &_type_sight:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSight_dark');
-        }
+    }
 
     &_type_settlement:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSettlement_dark');
-        }
     }
+}
 
 a.dg-map-geoclicker__show-more-sights-link {
     color: #ffe6aa;
 
-    .no-touch &:hover {
+    &:hover {
         color: #9cd;
-        }
+    }
 
     &:after {
         .notRepeatableBg('DGGeoclicker__arrowLeft_dark');
-        }
     }
+}
 
 .dg-map-geoclicker__drilldown {
     color: #aaa;
-    }
+}

--- a/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-map-geoclicker.less
@@ -25,7 +25,7 @@
 a.dg-map-geoclicker__show-more-sights-link {
     color: #ffe6aa;
 
-    .no-touch &:hover {
+    &:hover {
         color: #9cd;
         }
 

--- a/src/DGGeoclicker/skin/dark/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-popup.less
@@ -1,56 +1,56 @@
 a.dg-popup__link {
-    background-image: linear-gradient(to right, rgba(255, 230, 170, .3), rgba(255, 230, 170, .3) 100%);
+    background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
     color: #ffe6aa;
 
-    &:hover {
-        background-image: linear-gradient(to right, rgba(153, 204, 221, .3), rgba(153, 204, 221, .3) 100%);
+    .no-touch &:hover {
+        background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
         color: #9cd;
+        }
     }
-}
 
 .dg-popup__header-title {
     color: #ffc84b;
-}
+    }
 
 .dg-popup__footer-button-wrapper .dg-popup__footer-button,
 .dg-popup__footer-button-wrapper .dg-popup__footer-button:hover {
     color: #e6e6e6;
-}
+    }
 
 .dg-popup__footer-button {
-    background: rgba(0, 0, 0, .2);
-    box-shadow: 0 1px rgba(0, 0, 0, .1);
+    background: rgba(0,0,0,.2);
+    box-shadow: 0 1px rgba(0,0,0,.1);
 
-    &:hover {
+    .no-touch &:hover {
         background: #222;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, .5);
+        box-shadow: 0 1px 3px rgba(0,0,0,.5);
+        }
     }
-}
 
 .dg-popup__rating {
     .repeatableBg('DGPopup__ratingStarOff_dark');
-}
+    }
 
 .dg-popup__link_type_photos:before {
     .notRepeatableBgWithSizes('DGPopup__photoIcon_dark');
-}
+    }
 
 .dg-popup__button_name_firm-card-back:before {
     .notRepeatableBg('DGPopup__backIcon_dark');
-}
+    }
 
 .dg-popup__button_name_firm-list-back:before {
     .notRepeatableBg('DGPopup__backIcon_dark');
-}
+    }
 
 .dg-popup__button_name_back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_dark');
-}
+    }
 
 .dg-popup__button_name_goto:before {
     .notRepeatableBgWithSizes('DGPopup__pathIcon_dark');
-}
+    }
 
 .dg-popup__button_name_show-entrance:before {
     .notRepeatableBg('DGPopup__entranceIcon_dark');
-}
+    }

--- a/src/DGGeoclicker/skin/dark/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-popup.less
@@ -1,56 +1,56 @@
 a.dg-popup__link {
-    background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
+    background-image: linear-gradient(to right, rgba(255, 230, 170, .3), rgba(255, 230, 170, .3) 100%);
     color: #ffe6aa;
 
-    .no-touch &:hover {
-        background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
+    &:hover {
+        background-image: linear-gradient(to right, rgba(153, 204, 221, .3), rgba(153, 204, 221, .3) 100%);
         color: #9cd;
-        }
     }
+}
 
 .dg-popup__header-title {
     color: #ffc84b;
-    }
+}
 
 .dg-popup__footer-button-wrapper .dg-popup__footer-button,
 .dg-popup__footer-button-wrapper .dg-popup__footer-button:hover {
     color: #e6e6e6;
-    }
+}
 
 .dg-popup__footer-button {
-    background: rgba(0,0,0,.2);
-    box-shadow: 0 1px rgba(0,0,0,.1);
+    background: rgba(0, 0, 0, .2);
+    box-shadow: 0 1px rgba(0, 0, 0, .1);
 
-    .no-touch &:hover {
+    &:hover {
         background: #222;
-        box-shadow: 0 1px 3px rgba(0,0,0,.5);
-        }
+        box-shadow: 0 1px 3px rgba(0, 0, 0, .5);
     }
+}
 
 .dg-popup__rating {
     .repeatableBg('DGPopup__ratingStarOff_dark');
-    }
+}
 
 .dg-popup__link_type_photos:before {
     .notRepeatableBgWithSizes('DGPopup__photoIcon_dark');
-    }
+}
 
 .dg-popup__button_name_firm-card-back:before {
     .notRepeatableBg('DGPopup__backIcon_dark');
-    }
+}
 
 .dg-popup__button_name_firm-list-back:before {
     .notRepeatableBg('DGPopup__backIcon_dark');
-    }
+}
 
 .dg-popup__button_name_back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_dark');
-    }
+}
 
 .dg-popup__button_name_goto:before {
     .notRepeatableBgWithSizes('DGPopup__pathIcon_dark');
-    }
+}
 
 .dg-popup__button_name_show-entrance:before {
     .notRepeatableBg('DGPopup__entranceIcon_dark');
-    }
+}

--- a/src/DGGeoclicker/skin/dark/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/dark/less/dg-popup.less
@@ -2,7 +2,7 @@ a.dg-popup__link {
     background-image: linear-gradient(to right, rgba(255,230,170,.3), rgba(255,230,170,.3) 100%);
     color: #ffe6aa;
 
-    .no-touch &:hover {
+    &:hover {
         background-image: linear-gradient(to right, rgba(153,204,221,.3), rgba(153,204,221,.3) 100%);
         color: #9cd;
         }
@@ -21,7 +21,7 @@ a.dg-popup__link {
     background: rgba(0,0,0,.2);
     box-shadow: 0 1px rgba(0,0,0,.1);
 
-    .no-touch &:hover {
+    &:hover {
         background: #222;
         box-shadow: 0 1px 3px rgba(0,0,0,.5);
         }

--- a/src/DGGeoclicker/skin/light/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/light/less/dg-firm-card.less
@@ -1,37 +1,37 @@
-
 .dg-firm-card__link a {
-    background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
+    background-image: linear-gradient(to right, rgba(0, 91, 143, .3), rgba(0, 91, 143, .3) 100%);
     color: #005b8f;
 
-    .no-touch &:hover {
-        background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
+    &:hover {
+        background-image: linear-gradient(to right, rgba(0, 0, 0, .3), rgba(0, 0, 0, .3) 100%);
         color: #000;
-        }
     }
+}
 
 .dg-firm-card__comment {
     color: #666;
-    }
+}
 
 .dg-firm-card__rubrics {
     color: #666;
-    }
-    .dg-firm-card__rubrics-list-item:after {
-        color: #666;
-        }
+}
+
+.dg-firm-card__rubrics-list-item:after {
+    color: #666;
+}
 
 .dg-firm-card__address:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_light');
-    }
+}
 
 .dg-firm-card__phone:before {
     .notRepeatableBgWithSizes('DGFirmCard__phoneIcon_light');
-    }
+}
 
 .dg-firm-card__site:before {
     .notRepeatableBgWithSizes('DGFirmCard__siteIcon_light');
-    }
+}
 
 .dg-firm-card__email:before {
     .notRepeatableBgWithSizes('DGFirmCard__mailIcon_light');
-    }
+}

--- a/src/DGGeoclicker/skin/light/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/light/less/dg-firm-card.less
@@ -1,37 +1,37 @@
+
 .dg-firm-card__link a {
-    background-image: linear-gradient(to right, rgba(0, 91, 143, .3), rgba(0, 91, 143, .3) 100%);
+    background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
     color: #005b8f;
 
-    &:hover {
-        background-image: linear-gradient(to right, rgba(0, 0, 0, .3), rgba(0, 0, 0, .3) 100%);
+    .no-touch &:hover {
+        background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
         color: #000;
+        }
     }
-}
 
 .dg-firm-card__comment {
     color: #666;
-}
+    }
 
 .dg-firm-card__rubrics {
     color: #666;
-}
-
-.dg-firm-card__rubrics-list-item:after {
-    color: #666;
-}
+    }
+    .dg-firm-card__rubrics-list-item:after {
+        color: #666;
+        }
 
 .dg-firm-card__address:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_light');
-}
+    }
 
 .dg-firm-card__phone:before {
     .notRepeatableBgWithSizes('DGFirmCard__phoneIcon_light');
-}
+    }
 
 .dg-firm-card__site:before {
     .notRepeatableBgWithSizes('DGFirmCard__siteIcon_light');
-}
+    }
 
 .dg-firm-card__email:before {
     .notRepeatableBgWithSizes('DGFirmCard__mailIcon_light');
-}
+    }

--- a/src/DGGeoclicker/skin/light/less/dg-firm-card.less
+++ b/src/DGGeoclicker/skin/light/less/dg-firm-card.less
@@ -3,7 +3,7 @@
     background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
     color: #005b8f;
 
-    .no-touch &:hover {
+    &:hover {
         background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
         color: #000;
         }

--- a/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
@@ -1,38 +1,39 @@
+
 .dg-map-geoclicker__address-header:first-child:before,
 .dg-map-geoclicker__address-drilldown:first-child:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_light');
-}
+    }
 
 .dg-map-geoclicker__purpose {
     &:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purpose_light');
-    }
+        }
 
     &_type_street:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeStreet_light');
-    }
+        }
 
     &_type_sight:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSight_light');
-    }
+        }
 
     &_type_settlement:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSettlement_light');
+        }
     }
-}
 
 a.dg-map-geoclicker__show-more-sights-link {
     color: #005b8f;
 
-    &:hover {
+    .no-touch &:hover {
         color: #000;
-    }
+        }
 
     &:after {
         .notRepeatableBg('DGGeoclicker__arrowLeft_light');
+        }
     }
-}
 
 .dg-map-geoclicker__drilldown {
     color: #666;
-}
+    }

--- a/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
@@ -1,39 +1,38 @@
-
 .dg-map-geoclicker__address-header:first-child:before,
 .dg-map-geoclicker__address-drilldown:first-child:before {
     .notRepeatableBgWithSizes('DGBuildingCallout__marker_light');
-    }
+}
 
 .dg-map-geoclicker__purpose {
     &:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purpose_light');
-        }
+    }
 
     &_type_street:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeStreet_light');
-        }
+    }
 
     &_type_sight:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSight_light');
-        }
+    }
 
     &_type_settlement:before {
         .notRepeatableBgWithSizes('DGGeoclicker__purposeSettlement_light');
-        }
     }
+}
 
 a.dg-map-geoclicker__show-more-sights-link {
     color: #005b8f;
 
-    .no-touch &:hover {
+    &:hover {
         color: #000;
-        }
+    }
 
     &:after {
         .notRepeatableBg('DGGeoclicker__arrowLeft_light');
-        }
     }
+}
 
 .dg-map-geoclicker__drilldown {
     color: #666;
-    }
+}

--- a/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
+++ b/src/DGGeoclicker/skin/light/less/dg-map-geoclicker.less
@@ -25,7 +25,7 @@
 a.dg-map-geoclicker__show-more-sights-link {
     color: #005b8f;
 
-    .no-touch &:hover {
+    &:hover {
         color: #000;
         }
 

--- a/src/DGGeoclicker/skin/light/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/light/less/dg-popup.less
@@ -2,7 +2,7 @@ a.dg-popup__link {
     background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
     color: #005b8f;
 
-    .no-touch &:hover {
+    &:hover {
         background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
         color: #000;
         }
@@ -11,7 +11,7 @@ a.dg-popup__link {
 .dg-popup__footer-button-wrapper .dg-popup__footer-button {
     color: #647882;
 
-    .no-touch &:hover {
+    &:hover {
         color: #286482;
         }
     }
@@ -21,7 +21,7 @@ a.dg-popup__link {
     background: #f5faff;
     box-shadow: 0 1px rgba(0,0,0,.1);
 
-    .no-touch &:hover {
+    &:hover {
         background: #e7f3ff;
         }
     }

--- a/src/DGGeoclicker/skin/light/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/light/less/dg-popup.less
@@ -1,55 +1,56 @@
 a.dg-popup__link {
-    background-image: linear-gradient(to right, rgba(0, 91, 143, .3), rgba(0, 91, 143, .3) 100%);
+    background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
     color: #005b8f;
 
-    &:hover {
-        background-image: linear-gradient(to right, rgba(0, 0, 0, .3), rgba(0, 0, 0, .3) 100%);
+    .no-touch &:hover {
+        background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
         color: #000;
+        }
     }
-}
 
 .dg-popup__footer-button-wrapper .dg-popup__footer-button {
     color: #647882;
 
-    &:hover {
+    .no-touch &:hover {
         color: #286482;
+        }
     }
-}
 
 .dg-popup__footer-button {
     border: 1px solid #e9edf2;
     background: #f5faff;
-    box-shadow: 0 1px rgba(0, 0, 0, .1);
+    box-shadow: 0 1px rgba(0,0,0,.1);
 
-    &:hover {
+    .no-touch &:hover {
         background: #e7f3ff;
+        }
     }
-}
 
 .dg-popup__rating {
     .repeatableBg('DGPopup__ratingStarOff_light');
-}
+    }
 
 .dg-popup__link_type_photos:before {
     .notRepeatableBgWithSizes('DGPopup__photoIcon_light');
-}
+    }
 
 .dg-popup__button_name_firm-card-back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-}
+    }
 
 .dg-popup__button_name_firm-list-back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-}
+    }
 
 .dg-popup__button_name_back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-}
+    }
 
 .dg-popup__button_name_goto:before {
     .notRepeatableBg('DGPopup__pathIcon_light');
-}
+    }
 
 .dg-popup__button_name_show-entrance:before {
     .notRepeatableBg('DGPopup__entranceIcon_light');
-}
+    }
+

--- a/src/DGGeoclicker/skin/light/less/dg-popup.less
+++ b/src/DGGeoclicker/skin/light/less/dg-popup.less
@@ -1,56 +1,55 @@
 a.dg-popup__link {
-    background-image: linear-gradient(to right, rgba(0,91,143,.3), rgba(0,91,143,.3) 100%);
+    background-image: linear-gradient(to right, rgba(0, 91, 143, .3), rgba(0, 91, 143, .3) 100%);
     color: #005b8f;
 
-    .no-touch &:hover {
-        background-image: linear-gradient(to right, rgba(0,0,0,.3), rgba(0,0,0,.3) 100%);
+    &:hover {
+        background-image: linear-gradient(to right, rgba(0, 0, 0, .3), rgba(0, 0, 0, .3) 100%);
         color: #000;
-        }
     }
+}
 
 .dg-popup__footer-button-wrapper .dg-popup__footer-button {
     color: #647882;
 
-    .no-touch &:hover {
+    &:hover {
         color: #286482;
-        }
     }
+}
 
 .dg-popup__footer-button {
     border: 1px solid #e9edf2;
     background: #f5faff;
-    box-shadow: 0 1px rgba(0,0,0,.1);
+    box-shadow: 0 1px rgba(0, 0, 0, .1);
 
-    .no-touch &:hover {
+    &:hover {
         background: #e7f3ff;
-        }
     }
+}
 
 .dg-popup__rating {
     .repeatableBg('DGPopup__ratingStarOff_light');
-    }
+}
 
 .dg-popup__link_type_photos:before {
     .notRepeatableBgWithSizes('DGPopup__photoIcon_light');
-    }
+}
 
 .dg-popup__button_name_firm-card-back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-    }
+}
 
 .dg-popup__button_name_firm-list-back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-    }
+}
 
 .dg-popup__button_name_back:before {
     .notRepeatableBgWithSizes('DGPopup__backIcon_light');
-    }
+}
 
 .dg-popup__button_name_goto:before {
     .notRepeatableBg('DGPopup__pathIcon_light');
-    }
+}
 
 .dg-popup__button_name_show-entrance:before {
     .notRepeatableBg('DGPopup__entranceIcon_light');
-    }
-
+}

--- a/src/DGLocation/skin/basic/less/dg-control-round.less
+++ b/src/DGLocation/skin/basic/less/dg-control-round.less
@@ -1,4 +1,3 @@
-
 .dg-control-round__icon_name_locate {
     &:after {
         position: absolute;
@@ -8,15 +7,17 @@
         left: 0;
         margin: auto;
         content: '';
-        }
+    }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__locateIconEnabled');
-        }
     }
+}
 
 @keyframes DGLocation__locateIconRequestingAnim {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
     }
+}

--- a/src/DGLocation/skin/basic/less/dg-control-round.less
+++ b/src/DGLocation/skin/basic/less/dg-control-round.less
@@ -11,7 +11,7 @@
         }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__locateIconEnabled');
         }

--- a/src/DGLocation/skin/basic/less/dg-control-round.less
+++ b/src/DGLocation/skin/basic/less/dg-control-round.less
@@ -1,3 +1,4 @@
+
 .dg-control-round__icon_name_locate {
     &:after {
         position: absolute;
@@ -7,17 +8,15 @@
         left: 0;
         margin: auto;
         content: '';
-    }
+        }
 
     .dg-control-round__icon_state_active&:after,
-    .dg-control-round__icon_state_active&:hover:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__locateIconEnabled');
+        }
     }
-}
 
 @keyframes DGLocation__locateIconRequestingAnim {
-    to {
-        transform: rotate(360deg);
+    to { transform: rotate(360deg); }
     }
-}

--- a/src/DGLocation/skin/dark/less/dg-control-round.less
+++ b/src/DGLocation/skin/dark/less/dg-control-round.less
@@ -3,13 +3,13 @@
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_dark');
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_dark');
         }
 
     .dg-control-round__icon_state_requesting&:after,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_dark');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;

--- a/src/DGLocation/skin/dark/less/dg-control-round.less
+++ b/src/DGLocation/skin/dark/less/dg-control-round.less
@@ -1,18 +1,18 @@
 .dg-control-round__icon_name_locate {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_dark');
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_dark');
-    }
+        }
 
     .dg-control-round__icon_state_requesting&:after,
-    .dg-control-round__icon_state_requesting&:hover:after,
+    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_dark');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;
+        }
     }
-}

--- a/src/DGLocation/skin/dark/less/dg-control-round.less
+++ b/src/DGLocation/skin/dark/less/dg-control-round.less
@@ -1,18 +1,18 @@
 .dg-control-round__icon_name_locate {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_dark');
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_dark');
-        }
+    }
 
     .dg-control-round__icon_state_requesting&:after,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_dark');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;
-        }
     }
+}

--- a/src/DGLocation/skin/light/less/dg-control-round.less
+++ b/src/DGLocation/skin/light/less/dg-control-round.less
@@ -1,18 +1,18 @@
 .dg-control-round__icon_name_locate {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_light');
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_light');
-    }
+        }
 
     .dg-control-round__icon_state_requesting&:after,
-    .dg-control-round__icon_state_requesting&:hover:after,
+    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_light');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;
+        }
     }
-}

--- a/src/DGLocation/skin/light/less/dg-control-round.less
+++ b/src/DGLocation/skin/light/less/dg-control-round.less
@@ -3,13 +3,13 @@
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_light');
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_light');
         }
 
     .dg-control-round__icon_state_requesting&:after,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_light');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;

--- a/src/DGLocation/skin/light/less/dg-control-round.less
+++ b/src/DGLocation/skin/light/less/dg-control-round.less
@@ -1,18 +1,18 @@
 .dg-control-round__icon_name_locate {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIcon_light');
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__locateIconHover_light');
-        }
+    }
 
     .dg-control-round__icon_state_requesting&:after,
-    .no-touch .dg-control-round__icon_state_requesting&:hover:after,
+    .dg-control-round__icon_state_requesting&:hover:after,
     .dg-control-round__icon_state_requesting&:active:after {
         .notRepeatableBgWithSizes('DGRoundControl__locateIconRequesting_light');
         animation: DGLocation__locateIconRequestingAnim 1s linear infinite;
         image-rendering: optimizeQuality;
-        }
     }
+}

--- a/src/DGPopup/skin/basic/less/leaflet.less
+++ b/src/DGPopup/skin/basic/less/leaflet.less
@@ -1,13 +1,14 @@
 .leaflet-popup {
     margin-bottom: 0;
-    }
+}
 
 .leaflet-popup-tip-container {
     height: 0;
-    }
-    .leaflet-popup-tip {
-        display: none;
-        }
+}
+
+.leaflet-popup-tip {
+    display: none;
+}
 
 .leaflet-popup-content-wrapper {
     overflow: hidden;
@@ -20,10 +21,9 @@
     box-shadow: none;
     color: #e6e6e6;
     font-size: 14px;
-    transition:
-        opacity ease-out .2s,
-        max-height ease-out .2s,
-        height ease-out .2s;
+    transition: opacity ease-out .2s,
+    max-height ease-out .2s,
+    height ease-out .2s;
     transform-origin: 50% 100%;
 
     // Чтобы текст не заезжал под кнопку закрытия. Для не инлайновых боксов
@@ -35,55 +35,56 @@
         // но минимум проблем с не инлайновыми боксами
         height: 17px;
         content: '';
-        }
     }
-    .leaflet-popup-content {
-        position: relative;
-        margin: 16px;
-        width: auto;
-        line-height: 1.4;
-        }
+}
+
+.leaflet-popup-content {
+    position: relative;
+    margin: 16px;
+    width: auto;
+    line-height: 1.4;
+}
 
 .leaflet-popup a {
     outline: none;
-    }
+}
 
 .leaflet-popup-content p {
     margin: 0;
-    }
+}
 
 .leaflet-popup-scrolled {
     overflow: visible;
     border: 0;
-    }
+}
 
 .leaflet-popup-inner {
     position: relative;
     z-index: 0;
-    }
+}
 
 .leaflet-popup_show_true {
-    transition:
-        transform ease-in-out .2s,
-        opacity ease-in-out .2s,
-        height ease-out .2s;
+    transition: transform ease-in-out .2s,
+    opacity ease-in-out .2s,
+    height ease-out .2s;
     transform: scale(1);
-    }
+}
 
 .leaflet-popup_show_false {
     opacity: 0 !important;
     transition: all ease-in-out .1s;
     transform: scale(.2);
-    }
+}
 
 /* Коллаут показался, но контент ещё не загрузился */
 .leaflet-popup_preloader_true {
     width: 384px;
     height: 52px;
-    }
+}
 
 /* В коллауте ошибка вместо контента */
-.leaflet-popup_error_true {}
+.leaflet-popup_error_true {
+}
 
 .leaflet-map-pane .leaflet-popup-tip-container {
     position: absolute;
@@ -96,16 +97,17 @@
     background-repeat: no-repeat;
     transform: translateY(47px);
     pointer-events: none;
-    }
-    .leaflet-popup-tip {
-        display: none;
-        }
+}
+
+.leaflet-popup-tip {
+    display: none;
+}
 
 .leaflet-popup-tip-container_svg {
     .notRepeatableBg('DGPopup__popupShadow', true);
     background-position: 50% 95%;
     background-size: 36px 12px;
-    }
+}
 
 .leaflet-container a.leaflet-popup-close-button {
     position: absolute;
@@ -122,10 +124,10 @@
     line-height: 30px;
     cursor: pointer;
 
-    .no-touch &:hover {
+    &:hover {
         border-radius: 2px;
         transition: all .2s;
-        }
+    }
 
     &:active {
         color: #777777;
@@ -139,5 +141,5 @@
         width: 40px;
         height: 40px;
         content: '';
-        }
     }
+}

--- a/src/DGPopup/skin/basic/less/leaflet.less
+++ b/src/DGPopup/skin/basic/less/leaflet.less
@@ -1,14 +1,13 @@
 .leaflet-popup {
     margin-bottom: 0;
-}
+    }
 
 .leaflet-popup-tip-container {
     height: 0;
-}
-
-.leaflet-popup-tip {
-    display: none;
-}
+    }
+    .leaflet-popup-tip {
+        display: none;
+        }
 
 .leaflet-popup-content-wrapper {
     overflow: hidden;
@@ -21,9 +20,10 @@
     box-shadow: none;
     color: #e6e6e6;
     font-size: 14px;
-    transition: opacity ease-out .2s,
-    max-height ease-out .2s,
-    height ease-out .2s;
+    transition:
+        opacity ease-out .2s,
+        max-height ease-out .2s,
+        height ease-out .2s;
     transform-origin: 50% 100%;
 
     // Чтобы текст не заезжал под кнопку закрытия. Для не инлайновых боксов
@@ -35,56 +35,55 @@
         // но минимум проблем с не инлайновыми боксами
         height: 17px;
         content: '';
+        }
     }
-}
-
-.leaflet-popup-content {
-    position: relative;
-    margin: 16px;
-    width: auto;
-    line-height: 1.4;
-}
+    .leaflet-popup-content {
+        position: relative;
+        margin: 16px;
+        width: auto;
+        line-height: 1.4;
+        }
 
 .leaflet-popup a {
     outline: none;
-}
+    }
 
 .leaflet-popup-content p {
     margin: 0;
-}
+    }
 
 .leaflet-popup-scrolled {
     overflow: visible;
     border: 0;
-}
+    }
 
 .leaflet-popup-inner {
     position: relative;
     z-index: 0;
-}
+    }
 
 .leaflet-popup_show_true {
-    transition: transform ease-in-out .2s,
-    opacity ease-in-out .2s,
-    height ease-out .2s;
+    transition:
+        transform ease-in-out .2s,
+        opacity ease-in-out .2s,
+        height ease-out .2s;
     transform: scale(1);
-}
+    }
 
 .leaflet-popup_show_false {
     opacity: 0 !important;
     transition: all ease-in-out .1s;
     transform: scale(.2);
-}
+    }
 
 /* Коллаут показался, но контент ещё не загрузился */
 .leaflet-popup_preloader_true {
     width: 384px;
     height: 52px;
-}
+    }
 
 /* В коллауте ошибка вместо контента */
-.leaflet-popup_error_true {
-}
+.leaflet-popup_error_true {}
 
 .leaflet-map-pane .leaflet-popup-tip-container {
     position: absolute;
@@ -97,17 +96,16 @@
     background-repeat: no-repeat;
     transform: translateY(47px);
     pointer-events: none;
-}
-
-.leaflet-popup-tip {
-    display: none;
-}
+    }
+    .leaflet-popup-tip {
+        display: none;
+        }
 
 .leaflet-popup-tip-container_svg {
     .notRepeatableBg('DGPopup__popupShadow', true);
     background-position: 50% 95%;
     background-size: 36px 12px;
-}
+    }
 
 .leaflet-container a.leaflet-popup-close-button {
     position: absolute;
@@ -124,10 +122,10 @@
     line-height: 30px;
     cursor: pointer;
 
-    &:hover {
+    .no-touch &:hover {
         border-radius: 2px;
         transition: all .2s;
-    }
+        }
 
     &:active {
         color: #777777;
@@ -141,5 +139,5 @@
         width: 40px;
         height: 40px;
         content: '';
+        }
     }
-}

--- a/src/DGPopup/skin/basic/less/leaflet.less
+++ b/src/DGPopup/skin/basic/less/leaflet.less
@@ -122,7 +122,7 @@
     line-height: 30px;
     cursor: pointer;
 
-    .no-touch &:hover {
+    &:hover {
         border-radius: 2px;
         transition: all .2s;
         }

--- a/src/DGPopup/skin/dark/less/leaflet.less
+++ b/src/DGPopup/skin/dark/less/leaflet.less
@@ -1,25 +1,25 @@
 .leaflet-popup-content-wrapper {
     background-color: rgba(50, 50, 50, .9);
-    }
+}
 
 .leaflet-popup-tip-container_image {
     .notRepeatableBg('DGPopup__popupShadow_dark', true);
-    }
+}
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     fill: rgba(50, 50, 50, .9);
-    }
+}
 
 .leaflet-container a.leaflet-popup-close-button {
-    .no-touch &:hover {
+    &:hover {
         background-color: #222;
-        box-shadow: 0 1px 3px rgba(0,0,0,.5);
-        }
+        box-shadow: 0 1px 3px rgba(0, 0, 0, .5);
+    }
 
     &:after {
         top: -3px;
         right: -5px;
         width: 40px;
         height: 40px;
-        }
     }
+}

--- a/src/DGPopup/skin/dark/less/leaflet.less
+++ b/src/DGPopup/skin/dark/less/leaflet.less
@@ -11,7 +11,7 @@
     }
 
 .leaflet-container a.leaflet-popup-close-button {
-    .no-touch &:hover {
+    &:hover {
         background-color: #222;
         box-shadow: 0 1px 3px rgba(0,0,0,.5);
         }

--- a/src/DGPopup/skin/dark/less/leaflet.less
+++ b/src/DGPopup/skin/dark/less/leaflet.less
@@ -1,25 +1,25 @@
 .leaflet-popup-content-wrapper {
     background-color: rgba(50, 50, 50, .9);
-}
+    }
 
 .leaflet-popup-tip-container_image {
     .notRepeatableBg('DGPopup__popupShadow_dark', true);
-}
+    }
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     fill: rgba(50, 50, 50, .9);
-}
+    }
 
 .leaflet-container a.leaflet-popup-close-button {
-    &:hover {
+    .no-touch &:hover {
         background-color: #222;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, .5);
-    }
+        box-shadow: 0 1px 3px rgba(0,0,0,.5);
+        }
 
     &:after {
         top: -3px;
         right: -5px;
         width: 40px;
         height: 40px;
+        }
     }
-}

--- a/src/DGPopup/skin/light/less/leaflet.less
+++ b/src/DGPopup/skin/light/less/leaflet.less
@@ -21,7 +21,7 @@
     }
 
 .leaflet-container a.leaflet-popup-close-button {
-    .no-touch &:hover {
+    &:hover {
         background-color: #f5faff;
         color: #6fa4d9;
         }

--- a/src/DGPopup/skin/light/less/leaflet.less
+++ b/src/DGPopup/skin/light/less/leaflet.less
@@ -1,35 +1,35 @@
 .leaflet-popup-content-wrapper {
     border: 1px solid #bebdb5;
-    border-color: rgba(151,151,151,.6);
+    border-color: rgba(151, 151, 151, .6);
     background-color: rgba(255, 255, 255, .95);
     color: #000;
-    }
+}
 
 .leaflet-popup-tip-container_image {
     .notRepeatableBg('DGPopup__popupShadow_light', true);
-    }
+}
 
 .leaflet-map-pane .leaflet-popup-tip-container {
     transform: translateY(46px);
-    }
+}
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     margin-top: -2px;
     fill: rgba(255, 255, 255, .95);
     stroke: #bebdb5;
-    stroke-dasharray: 0,10,100,60;
-    }
+    stroke-dasharray: 0, 10, 100, 60;
+}
 
 .leaflet-container a.leaflet-popup-close-button {
-    .no-touch &:hover {
+    &:hover {
         background-color: #f5faff;
         color: #6fa4d9;
-        }
+    }
 
     &:after {
         top: -3px;
         right: -5px;
         width: 40px;
         height: 40px;
-        }
     }
+}

--- a/src/DGPopup/skin/light/less/leaflet.less
+++ b/src/DGPopup/skin/light/less/leaflet.less
@@ -1,35 +1,35 @@
 .leaflet-popup-content-wrapper {
     border: 1px solid #bebdb5;
-    border-color: rgba(151, 151, 151, .6);
+    border-color: rgba(151,151,151,.6);
     background-color: rgba(255, 255, 255, .95);
     color: #000;
-}
+    }
 
 .leaflet-popup-tip-container_image {
     .notRepeatableBg('DGPopup__popupShadow_light', true);
-}
+    }
 
 .leaflet-map-pane .leaflet-popup-tip-container {
     transform: translateY(46px);
-}
+    }
 
 .leaflet-map-pane .leaflet-popup-tip-container_svg {
     margin-top: -2px;
     fill: rgba(255, 255, 255, .95);
     stroke: #bebdb5;
-    stroke-dasharray: 0, 10, 100, 60;
-}
+    stroke-dasharray: 0,10,100,60;
+    }
 
 .leaflet-container a.leaflet-popup-close-button {
-    &:hover {
+    .no-touch &:hover {
         background-color: #f5faff;
         color: #6fa4d9;
-    }
+        }
 
     &:after {
         top: -3px;
         right: -5px;
         width: 40px;
         height: 40px;
+        }
     }
-}

--- a/src/DGRoundControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/basic/less/dg-control-round.less
@@ -1,4 +1,3 @@
-
 .dg-control-round {
     position: relative;
     padding: 5px;
@@ -6,52 +5,52 @@
     height: 30px;
     border-radius: 50%;
     cursor: default;
+}
+
+.dg-control-round__icon {
+    position: relative;
+    display: block;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background-color: #f0f0f0; // 94%, fallback
+    background-image: linear-gradient(to bottom, #fff 0, hsl(0, 0%, 88%) 100%);
+    color: #2b2a29;
+    text-align: center;
+    text-decoration: none;
+    text-shadow: 0 1px 0 #fff;
+    font-size: 22px;
+    line-height: 30px;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #f5f5f5; // 96%, fallback
+        background-image: linear-gradient(to bottom, hsl(0, 0%, 92%) 0, #fff 100%);
     }
-    .dg-control-round__icon {
-        position: relative;
-        display: block;
-        width: 30px;
-        height: 30px;
-        border-radius: 50%;
-        background-color: #f0f0f0; // 94%, fallback
-        background-image: linear-gradient(to bottom, #fff 0, hsl(0,0%,88%) 100%);
-        color: #2b2a29;
-        text-align: center;
-        text-decoration: none;
-        text-shadow: 0 1px 0 #fff;
-        font-size: 22px;
-        line-height: 30px;
-        cursor: pointer;
 
-        .no-touch &:hover {
-            background-color: #f5f5f5; // 96%, fallback
-            background-image: linear-gradient(to bottom, hsl(0,0%,92%) 0, #fff 100%);
-            }
+    &:active,
+    &_state_active {
+        background-color: #ebebeb; // 92%, fallback
+        background-image: linear-gradient(to bottom, hsl(0, 0%, 84%) 0, #fff 100%);
+    }
 
-        &:active,
-        .no-touch &:active,
-        &_state_active {
-            background-color: #ebebeb; // 92%, fallback
-            background-image: linear-gradient(to bottom, hsl(0,0%,84%) 0, #fff 100%);
-            }
+    .leaflet-disabled &,
+    .leaflet-disabled &:hover,
+    .leaflet-disabled &:active {
+        background-image: none;
+        cursor: default;
+    }
 
-        .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
-        .leaflet-disabled &:active {
-            background-image: none;
-            cursor: default;
-            }
-
-        .leaflet-touch &:before {
-            position: absolute;
-            top: -10px;
-            right: -15px;
-            bottom: -10px;
-            left: -15px;
-            content: '';
-            }
-        }
+    .leaflet-touch &:before {
+        position: absolute;
+        top: -10px;
+        right: -15px;
+        bottom: -10px;
+        left: -15px;
+        content: '';
+    }
+}
 
 .dg-control-round_is-hidden_true {
     display: none;
-    }
+}

--- a/src/DGRoundControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/basic/less/dg-control-round.less
@@ -1,3 +1,4 @@
+
 .dg-control-round {
     position: relative;
     padding: 5px;
@@ -5,52 +6,52 @@
     height: 30px;
     border-radius: 50%;
     cursor: default;
-}
-
-.dg-control-round__icon {
-    position: relative;
-    display: block;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    background-color: #f0f0f0; // 94%, fallback
-    background-image: linear-gradient(to bottom, #fff 0, hsl(0, 0%, 88%) 100%);
-    color: #2b2a29;
-    text-align: center;
-    text-decoration: none;
-    text-shadow: 0 1px 0 #fff;
-    font-size: 22px;
-    line-height: 30px;
-    cursor: pointer;
-
-    &:hover {
-        background-color: #f5f5f5; // 96%, fallback
-        background-image: linear-gradient(to bottom, hsl(0, 0%, 92%) 0, #fff 100%);
     }
+    .dg-control-round__icon {
+        position: relative;
+        display: block;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        background-color: #f0f0f0; // 94%, fallback
+        background-image: linear-gradient(to bottom, #fff 0, hsl(0,0%,88%) 100%);
+        color: #2b2a29;
+        text-align: center;
+        text-decoration: none;
+        text-shadow: 0 1px 0 #fff;
+        font-size: 22px;
+        line-height: 30px;
+        cursor: pointer;
 
-    &:active,
-    &_state_active {
-        background-color: #ebebeb; // 92%, fallback
-        background-image: linear-gradient(to bottom, hsl(0, 0%, 84%) 0, #fff 100%);
-    }
+        .no-touch &:hover {
+            background-color: #f5f5f5; // 96%, fallback
+            background-image: linear-gradient(to bottom, hsl(0,0%,92%) 0, #fff 100%);
+            }
 
-    .leaflet-disabled &,
-    .leaflet-disabled &:hover,
-    .leaflet-disabled &:active {
-        background-image: none;
-        cursor: default;
-    }
+        &:active,
+        .no-touch &:active,
+        &_state_active {
+            background-color: #ebebeb; // 92%, fallback
+            background-image: linear-gradient(to bottom, hsl(0,0%,84%) 0, #fff 100%);
+            }
 
-    .leaflet-touch &:before {
-        position: absolute;
-        top: -10px;
-        right: -15px;
-        bottom: -10px;
-        left: -15px;
-        content: '';
-    }
-}
+        .leaflet-disabled &,
+        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:active {
+            background-image: none;
+            cursor: default;
+            }
+
+        .leaflet-touch &:before {
+            position: absolute;
+            top: -10px;
+            right: -15px;
+            bottom: -10px;
+            left: -15px;
+            content: '';
+            }
+        }
 
 .dg-control-round_is-hidden_true {
     display: none;
-}
+    }

--- a/src/DGRoundControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/basic/less/dg-control-round.less
@@ -23,20 +23,19 @@
         line-height: 30px;
         cursor: pointer;
 
-        .no-touch &:hover {
+        &:hover {
             background-color: #f5f5f5; // 96%, fallback
             background-image: linear-gradient(to bottom, hsl(0,0%,92%) 0, #fff 100%);
             }
 
         &:active,
-        .no-touch &:active,
         &_state_active {
             background-color: #ebebeb; // 92%, fallback
             background-image: linear-gradient(to bottom, hsl(0,0%,84%) 0, #fff 100%);
             }
 
         .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:hover,
         .leaflet-disabled &:active {
             background-image: none;
             cursor: default;

--- a/src/DGRoundControl/skin/dark/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/dark/less/dg-control-round.less
@@ -6,7 +6,7 @@
     .dg-control-round__icon {
         box-shadow: 0 2px 2px 0 rgba(0,0,0,.4);
 
-        .no-touch &:hover {
+        &:hover {
             box-shadow:
                 inset 0 1px #fff,
                 0 0 0 1px rgba(0,0,0,.3),
@@ -14,7 +14,6 @@
             }
 
         &:active,
-        .no-touch &:active,
         &_state_active {
             box-shadow:
                 inset 0 1px 1px 1px rgba(0,0,0,.2),
@@ -23,7 +22,7 @@
             }
 
         .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:hover,
         .leaflet-disabled &:active {
             background-color: #b8b8b8; // 72%
             box-shadow: none;

--- a/src/DGRoundControl/skin/dark/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/dark/less/dg-control-round.less
@@ -1,31 +1,24 @@
-
 .dg-control-round {
     background-color: #3d3d3d; // 24%
-    box-shadow: 0 3px 5px 0 rgba(0,0,0,.3);
+    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, .3);
+}
+
+.dg-control-round__icon {
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .4);
+
+    &:hover {
+        box-shadow: inset 0 1px #fff, 0 0 0 1px rgba(0, 0, 0, .3), 0 1px 0 1px rgba(0, 0, 0, .4);
     }
-    .dg-control-round__icon {
-        box-shadow: 0 2px 2px 0 rgba(0,0,0,.4);
 
-        .no-touch &:hover {
-            box-shadow:
-                inset 0 1px #fff,
-                0 0 0 1px rgba(0,0,0,.3),
-                0 1px 0 1px rgba(0,0,0,.4);
-            }
+    &:active,
+    &_state_active {
+        box-shadow: inset 0 1px 1px 1px rgba(0, 0, 0, .2), 0 0 0 1px rgba(0, 0, 0, .3), 0 -1px 1px 0 #000;
+    }
 
-        &:active,
-        .no-touch &:active,
-        &_state_active {
-            box-shadow:
-                inset 0 1px 1px 1px rgba(0,0,0,.2),
-                0 0 0 1px rgba(0,0,0,.3),
-                0 -1px 1px 0 #000;
-            }
-
-        .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
-        .leaflet-disabled &:active {
-            background-color: #b8b8b8; // 72%
-            box-shadow: none;
-            }
-        }
+    .leaflet-disabled &,
+    .leaflet-disabled &:hover,
+    .leaflet-disabled &:active {
+        background-color: #b8b8b8; // 72%
+        box-shadow: none;
+    }
+}

--- a/src/DGRoundControl/skin/dark/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/dark/less/dg-control-round.less
@@ -1,24 +1,31 @@
+
 .dg-control-round {
     background-color: #3d3d3d; // 24%
-    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, .3);
-}
-
-.dg-control-round__icon {
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .4);
-
-    &:hover {
-        box-shadow: inset 0 1px #fff, 0 0 0 1px rgba(0, 0, 0, .3), 0 1px 0 1px rgba(0, 0, 0, .4);
+    box-shadow: 0 3px 5px 0 rgba(0,0,0,.3);
     }
+    .dg-control-round__icon {
+        box-shadow: 0 2px 2px 0 rgba(0,0,0,.4);
 
-    &:active,
-    &_state_active {
-        box-shadow: inset 0 1px 1px 1px rgba(0, 0, 0, .2), 0 0 0 1px rgba(0, 0, 0, .3), 0 -1px 1px 0 #000;
-    }
+        .no-touch &:hover {
+            box-shadow:
+                inset 0 1px #fff,
+                0 0 0 1px rgba(0,0,0,.3),
+                0 1px 0 1px rgba(0,0,0,.4);
+            }
 
-    .leaflet-disabled &,
-    .leaflet-disabled &:hover,
-    .leaflet-disabled &:active {
-        background-color: #b8b8b8; // 72%
-        box-shadow: none;
-    }
-}
+        &:active,
+        .no-touch &:active,
+        &_state_active {
+            box-shadow:
+                inset 0 1px 1px 1px rgba(0,0,0,.2),
+                0 0 0 1px rgba(0,0,0,.3),
+                0 -1px 1px 0 #000;
+            }
+
+        .leaflet-disabled &,
+        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:active {
+            background-color: #b8b8b8; // 72%
+            box-shadow: none;
+            }
+        }

--- a/src/DGRoundControl/skin/light/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/light/less/dg-control-round.less
@@ -9,7 +9,7 @@
         box-shadow: 0 0 1px 0 rgba(0,0,0,.4);
 
         .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:hover,
         .leaflet-disabled &:active {
             background-color: #e0e0e0; // 88%
             }

--- a/src/DGRoundControl/skin/light/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/light/less/dg-control-round.less
@@ -1,20 +1,18 @@
-
 .dg-control-round {
     background-color: #f0f0f0; // 94%
-    box-shadow:
-        0 0 0 1px #fff,
-        0 2px 5px 0 rgba(0,0,0,.3);
+    box-shadow: 0 0 0 1px #fff, 0 2px 5px 0 rgba(0, 0, 0, .3);
+}
+
+.dg-control-round__icon {
+    box-shadow: 0 0 1px 0 rgba(0, 0, 0, .4);
+
+    .leaflet-disabled &,
+    .leaflet-disabled &:hover,
+    .leaflet-disabled &:active {
+        background-color: #e0e0e0; // 88%
     }
-    .dg-control-round__icon {
-        box-shadow: 0 0 1px 0 rgba(0,0,0,.4);
 
-        .leaflet-disabled &,
-        .no-touch .leaflet-disabled &:hover,
-        .leaflet-disabled &:active {
-            background-color: #e0e0e0; // 88%
-            }
-
-        .leaflet-disabled & {
-            box-shadow: none;
-            }
-        }
+    .leaflet-disabled & {
+        box-shadow: none;
+    }
+}

--- a/src/DGRoundControl/skin/light/less/dg-control-round.less
+++ b/src/DGRoundControl/skin/light/less/dg-control-round.less
@@ -1,18 +1,20 @@
+
 .dg-control-round {
     background-color: #f0f0f0; // 94%
-    box-shadow: 0 0 0 1px #fff, 0 2px 5px 0 rgba(0, 0, 0, .3);
-}
-
-.dg-control-round__icon {
-    box-shadow: 0 0 1px 0 rgba(0, 0, 0, .4);
-
-    .leaflet-disabled &,
-    .leaflet-disabled &:hover,
-    .leaflet-disabled &:active {
-        background-color: #e0e0e0; // 88%
+    box-shadow:
+        0 0 0 1px #fff,
+        0 2px 5px 0 rgba(0,0,0,.3);
     }
+    .dg-control-round__icon {
+        box-shadow: 0 0 1px 0 rgba(0,0,0,.4);
 
-    .leaflet-disabled & {
-        box-shadow: none;
-    }
-}
+        .leaflet-disabled &,
+        .no-touch .leaflet-disabled &:hover,
+        .leaflet-disabled &:active {
+            background-color: #e0e0e0; // 88%
+            }
+
+        .leaflet-disabled & {
+            box-shadow: none;
+            }
+        }

--- a/src/DGRuler/skin/basic/less/dg-ruler.less
+++ b/src/DGRuler/skin/basic/less/dg-ruler.less
@@ -40,7 +40,7 @@
             vertical-align: top;
             transition: all .2s ease;
 
-            .no-touch &:hover {
+            &:hover {
                 transform: rotate(90deg);
                 }
             }
@@ -51,8 +51,4 @@
             right: -7px;
             bottom: -7px;
             width: 40px;
-
-            .no-touch & {
-                display: none;
-                }
             }

--- a/src/DGRuler/skin/basic/less/dg-ruler.less
+++ b/src/DGRuler/skin/basic/less/dg-ruler.less
@@ -7,50 +7,52 @@
     top: 0;
     left: 0;
     z-index: 200;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
-
-.dg-ruler__label-spacer {
-    display: block;
-}
-
-.dg-ruler__label-container {
-    display: none;
-    padding: 2px 4px;
-    border: 4px solid #fff;
-    border-radius: 13px;
-    background: #0da5d5;
-    background-clip: padding-box;
-    color: #fff;
-    white-space: nowrap;
-    font-size: 12px;
-}
-
-.dg-ruler__point {
-    display: inline-block;
-    margin: 2px 4px 0 0;
-    width: 10px;
-    height: 10px;
-    border-radius: 5px;
-    background: white;
-}
-
-.dg-ruler__label-remove-link {
-    .notRepeatableBgWithSizes('DGRuler__removeIcon');
-    display: none;
-    margin: 1px 0 0 4px;
-    vertical-align: top;
-    transition: all .2s ease;
-
-    &:hover {
-        transform: rotate(90deg);
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
     }
-}
+    .dg-ruler__label-spacer {
+        display: block;
+        }
 
-.dg-ruler__remove-link-overlay {
-    position: absolute;
-    top: -7px;
-    right: -7px;
-    bottom: -7px;
-    width: 40px;
-}
+    .dg-ruler__label-container {
+        display: none;
+        padding: 2px 4px;
+        border: 4px solid #fff;
+        border-radius: 13px;
+        background: #0da5d5;
+        background-clip: padding-box;
+        color: #fff;
+        white-space: nowrap;
+        font-size: 12px;
+        }
+        .dg-ruler__point {
+            display: inline-block;
+            margin: 2px 4px 0 0;
+            width: 10px;
+            height: 10px;
+            border-radius: 5px;
+            background: white;
+            }
+
+        .dg-ruler__label-remove-link {
+            .notRepeatableBgWithSizes('DGRuler__removeIcon');
+            display: none;
+            margin: 1px 0 0 4px;
+            vertical-align: top;
+            transition: all .2s ease;
+
+            .no-touch &:hover {
+                transform: rotate(90deg);
+                }
+            }
+
+        .dg-ruler__remove-link-overlay {
+            position: absolute;
+            top: -7px;
+            right: -7px;
+            bottom: -7px;
+            width: 40px;
+
+            .no-touch & {
+                display: none;
+                }
+            }

--- a/src/DGRuler/skin/basic/less/dg-ruler.less
+++ b/src/DGRuler/skin/basic/less/dg-ruler.less
@@ -7,52 +7,50 @@
     top: 0;
     left: 0;
     z-index: 200;
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.dg-ruler__label-spacer {
+    display: block;
+}
+
+.dg-ruler__label-container {
+    display: none;
+    padding: 2px 4px;
+    border: 4px solid #fff;
+    border-radius: 13px;
+    background: #0da5d5;
+    background-clip: padding-box;
+    color: #fff;
+    white-space: nowrap;
+    font-size: 12px;
+}
+
+.dg-ruler__point {
+    display: inline-block;
+    margin: 2px 4px 0 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+    background: white;
+}
+
+.dg-ruler__label-remove-link {
+    .notRepeatableBgWithSizes('DGRuler__removeIcon');
+    display: none;
+    margin: 1px 0 0 4px;
+    vertical-align: top;
+    transition: all .2s ease;
+
+    &:hover {
+        transform: rotate(90deg);
     }
-    .dg-ruler__label-spacer {
-        display: block;
-        }
+}
 
-    .dg-ruler__label-container {
-        display: none;
-        padding: 2px 4px;
-        border: 4px solid #fff;
-        border-radius: 13px;
-        background: #0da5d5;
-        background-clip: padding-box;
-        color: #fff;
-        white-space: nowrap;
-        font-size: 12px;
-        }
-        .dg-ruler__point {
-            display: inline-block;
-            margin: 2px 4px 0 0;
-            width: 10px;
-            height: 10px;
-            border-radius: 5px;
-            background: white;
-            }
-
-        .dg-ruler__label-remove-link {
-            .notRepeatableBgWithSizes('DGRuler__removeIcon');
-            display: none;
-            margin: 1px 0 0 4px;
-            vertical-align: top;
-            transition: all .2s ease;
-
-            .no-touch &:hover {
-                transform: rotate(90deg);
-                }
-            }
-
-        .dg-ruler__remove-link-overlay {
-            position: absolute;
-            top: -7px;
-            right: -7px;
-            bottom: -7px;
-            width: 40px;
-
-            .no-touch & {
-                display: none;
-                }
-            }
+.dg-ruler__remove-link-overlay {
+    position: absolute;
+    top: -7px;
+    right: -7px;
+    bottom: -7px;
+    width: 40px;
+}

--- a/src/DGRulerControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRulerControl/skin/basic/less/dg-control-round.less
@@ -11,13 +11,13 @@
         content: '';
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconHover');
         }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconEnabled');
         }

--- a/src/DGRulerControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRulerControl/skin/basic/less/dg-control-round.less
@@ -1,3 +1,4 @@
+
 .dg-control-round__icon_name_ruler {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__rulerIcon');
@@ -8,16 +9,16 @@
         left: 0;
         margin: auto;
         content: '';
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconHover');
-    }
+        }
 
     .dg-control-round__icon_state_active&:after,
-    .dg-control-round__icon_state_active&:hover:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconEnabled');
+        }
     }
-}

--- a/src/DGRulerControl/skin/basic/less/dg-control-round.less
+++ b/src/DGRulerControl/skin/basic/less/dg-control-round.less
@@ -1,4 +1,3 @@
-
 .dg-control-round__icon_name_ruler {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__rulerIcon');
@@ -9,16 +8,16 @@
         left: 0;
         margin: auto;
         content: '';
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconHover');
-        }
+    }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         .notRepeatableBg('DGRoundControl__rulerIconEnabled');
-        }
     }
+}

--- a/src/DGTrafficControl/skin/basic/less/dg-control-round.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-control-round.less
@@ -1,4 +1,3 @@
-
 .dg-control-round__icon_name_traffic {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__trafficIcon');
@@ -9,16 +8,16 @@
         left: 0;
         margin: auto;
         content: '';
-        }
+    }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__trafficIconHover');
-        }
+    }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         background-image: none;
-        }
     }
+}

--- a/src/DGTrafficControl/skin/basic/less/dg-control-round.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-control-round.less
@@ -11,13 +11,13 @@
         content: '';
         }
 
-    .no-touch &:hover:after,
+    &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__trafficIconHover');
         }
 
     .dg-control-round__icon_state_active&:after,
-    .no-touch .dg-control-round__icon_state_active&:hover:after,
+    .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         background-image: none;
         }

--- a/src/DGTrafficControl/skin/basic/less/dg-control-round.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-control-round.less
@@ -1,3 +1,4 @@
+
 .dg-control-round__icon_name_traffic {
     &:after {
         .notRepeatableBgWithSizes('DGRoundControl__trafficIcon');
@@ -8,16 +9,16 @@
         left: 0;
         margin: auto;
         content: '';
-    }
+        }
 
-    &:hover:after,
+    .no-touch &:hover:after,
     &:active:after {
         .notRepeatableBg('DGRoundControl__trafficIconHover');
-    }
+        }
 
     .dg-control-round__icon_state_active&:after,
-    .dg-control-round__icon_state_active&:hover:after,
+    .no-touch .dg-control-round__icon_state_active&:hover:after,
     .dg-control-round__icon_state_active&:active:after {
         background-image: none;
+        }
     }
-}

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
@@ -1,16 +1,16 @@
 .dg-traffic-control {
-    &_color_green {
+    .no-touch &_color_green {
         background: #3fc03b !important;
         font-weight: bold;
-    }
+        }
 
-    &_color_yellow {
+    .no-touch &_color_yellow {
         background: #f3b223 !important;
         font-weight: bold;
-    }
+        }
 
-    &_color_red {
+    .no-touch &_color_red {
         background: #eb240c !important;
         font-weight: bold;
+        }
     }
-}

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
@@ -1,16 +1,16 @@
 .dg-traffic-control {
-    .no-touch &_color_green {
+    &_color_green {
         background: #3fc03b !important;
         font-weight: bold;
-        }
+    }
 
-    .no-touch &_color_yellow {
+    &_color_yellow {
         background: #f3b223 !important;
         font-weight: bold;
-        }
+    }
 
-    .no-touch &_color_red {
+    &_color_red {
         background: #eb240c !important;
         font-weight: bold;
-        }
     }
+}

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.ie.less
@@ -1,15 +1,15 @@
 .dg-traffic-control {
-    .no-touch &_color_green {
+    &_color_green {
         background: #3fc03b !important;
         font-weight: bold;
         }
 
-    .no-touch &_color_yellow {
+    &_color_yellow {
         background: #f3b223 !important;
         font-weight: bold;
         }
 
-    .no-touch &_color_red {
+    &_color_red {
         background: #eb240c !important;
         font-weight: bold;
         }

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
@@ -2,7 +2,7 @@ a.dg-traffic-control {
     z-index: 0;
     color: #f2f2f2;
     text-decoration: none;
-    text-shadow: 0 1px 2px rgba(0,0,0,.3);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, .3);
     font: normal 15px/32px 'Arial narrow', Arial, sans-serif;
 
     &_color_green:after,
@@ -18,46 +18,44 @@ a.dg-traffic-control {
         width: 22px;
         height: 22px;
         border-radius: 50%;
-        box-shadow:
-            inset 0 1px 0 0 rgba(0,0,0,.2),
-            0 1px 0 0 #fff;
-        }
+        box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, .2), 0 1px 0 0 #fff;
+    }
 
-    .no-touch &:hover {
+    &:hover {
         color: #f2f2f2;
     }
 
-    .no-touch &_color_green:hover:after,
-    .no-touch &_color_yellow:hover:after,
-    .no-touch &_color_red:hover:after {
+    &_color_green:hover:after,
+    &_color_yellow:hover:after,
+    &_color_red:hover:after {
         width: 22px;
         height: 22px;
-        }
+    }
 
     &_color_green:after {
         background: #3fc03b;
-        }
+    }
 
-    .no-touch &_color_green:hover:after,
+    &_color_green:hover:after,
     &_color_green:active:after {
         background: linear-gradient(to top, #2aa731, #53e13a) #3ec435;
-        }
+    }
 
     &_color_yellow:after {
         background: #f3b223;
-        }
+    }
 
-    .no-touch &_color_yellow:hover:after,
+    &_color_yellow:hover:after,
     &_color_yellow:active:after {
         background: linear-gradient(to top, #ef931b, #f7be26) #f4a820;
-        }
+    }
 
     &_color_red:after {
         background: #eb240c;
-        }
+    }
 
-    .no-touch &_color_red:hover:after,
+    &_color_red:hover:after,
     &_color_red:active:after {
         background: linear-gradient(to top, #c01c0a, #f73416) #db2811;
-        }
     }
+}

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
@@ -23,13 +23,13 @@ a.dg-traffic-control {
             0 1px 0 0 #fff;
         }
 
-    .no-touch &:hover {
+    &:hover {
         color: #f2f2f2;
     }
 
-    .no-touch &_color_green:hover:after,
-    .no-touch &_color_yellow:hover:after,
-    .no-touch &_color_red:hover:after {
+    &_color_green:hover:after,
+    &_color_yellow:hover:after,
+    &_color_red:hover:after {
         width: 22px;
         height: 22px;
         }
@@ -38,7 +38,7 @@ a.dg-traffic-control {
         background: #3fc03b;
         }
 
-    .no-touch &_color_green:hover:after,
+    &_color_green:hover:after,
     &_color_green:active:after {
         background: linear-gradient(to top, #2aa731, #53e13a) #3ec435;
         }
@@ -47,7 +47,7 @@ a.dg-traffic-control {
         background: #f3b223;
         }
 
-    .no-touch &_color_yellow:hover:after,
+    &_color_yellow:hover:after,
     &_color_yellow:active:after {
         background: linear-gradient(to top, #ef931b, #f7be26) #f4a820;
         }
@@ -56,7 +56,7 @@ a.dg-traffic-control {
         background: #eb240c;
         }
 
-    .no-touch &_color_red:hover:after,
+    &_color_red:hover:after,
     &_color_red:active:after {
         background: linear-gradient(to top, #c01c0a, #f73416) #db2811;
         }

--- a/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
+++ b/src/DGTrafficControl/skin/basic/less/dg-traffic-control.less
@@ -2,7 +2,7 @@ a.dg-traffic-control {
     z-index: 0;
     color: #f2f2f2;
     text-decoration: none;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, .3);
+    text-shadow: 0 1px 2px rgba(0,0,0,.3);
     font: normal 15px/32px 'Arial narrow', Arial, sans-serif;
 
     &_color_green:after,
@@ -18,44 +18,46 @@ a.dg-traffic-control {
         width: 22px;
         height: 22px;
         border-radius: 50%;
-        box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, .2), 0 1px 0 0 #fff;
-    }
+        box-shadow:
+            inset 0 1px 0 0 rgba(0,0,0,.2),
+            0 1px 0 0 #fff;
+        }
 
-    &:hover {
+    .no-touch &:hover {
         color: #f2f2f2;
     }
 
-    &_color_green:hover:after,
-    &_color_yellow:hover:after,
-    &_color_red:hover:after {
+    .no-touch &_color_green:hover:after,
+    .no-touch &_color_yellow:hover:after,
+    .no-touch &_color_red:hover:after {
         width: 22px;
         height: 22px;
-    }
+        }
 
     &_color_green:after {
         background: #3fc03b;
-    }
+        }
 
-    &_color_green:hover:after,
+    .no-touch &_color_green:hover:after,
     &_color_green:active:after {
         background: linear-gradient(to top, #2aa731, #53e13a) #3ec435;
-    }
+        }
 
     &_color_yellow:after {
         background: #f3b223;
-    }
+        }
 
-    &_color_yellow:hover:after,
+    .no-touch &_color_yellow:hover:after,
     &_color_yellow:active:after {
         background: linear-gradient(to top, #ef931b, #f7be26) #f4a820;
-    }
+        }
 
     &_color_red:after {
         background: #eb240c;
-    }
+        }
 
-    &_color_red:hover:after,
+    .no-touch &_color_red:hover:after,
     &_color_red:active:after {
         background: linear-gradient(to top, #c01c0a, #f73416) #db2811;
+        }
     }
-}

--- a/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
@@ -1,135 +1,135 @@
 .dg-zoom {
     width: 40px;
     height: 74px;
-}
-
-.dg-zoom__in {
-    position: absolute;
-    top: 0;
-    left: 0;
-
-    .leaflet-touch &:before {
-        position: absolute;
-        top: -5px;
-        right: -10px;
-        bottom: 0;
-        left: -10px;
-        content: '';
     }
-
-    &:after {
-        position: absolute;
-        right: 0;
-        bottom: -1px;
-        left: 0;
-        z-index: -1;
-        margin: auto;
-        width: 12px;
-        height: 2px;
-        box-shadow: 0 0 3px 2px rgba(0, 0, 0, .3);
-        content: '';
-    }
-}
-
-.dg-zoom__button_type_in {
-    &:before,
-    .leaflet-touch &:before,
-    &:after {
+    .dg-zoom__in {
         position: absolute;
         top: 0;
-        right: 0;
-        bottom: 0;
         left: 0;
-        margin: auto;
-        width: 14px;
-        height: 2px;
-        background-color: #7a7a7a; // 48%
-        box-shadow: 0 1px #fff;
-        content: '';
-    }
 
-    &:after {
-        width: 2px;
-        height: 14px;
-    }
+        .leaflet-touch &:before {
+            position: absolute;
+            top: -5px;
+            right: -10px;
+            bottom: 0;
+            left: -10px;
+            content: '';
+            }
 
-    &:hover:before,
-    &:hover:after {
-        background-color: #616161; // 38%
-    }
+        &:after {
+            position: absolute;
+            right: 0;
+            bottom: -1px;
+            left: 0;
+            z-index: -1;
+            margin: auto;
+            width: 12px;
+            height: 2px;
+            box-shadow: 0 0 3px 2px rgba(0,0,0,.3);
+            content: '';
+            }
+        }
+        .dg-zoom__button_type_in {
+            &:before,
+            .leaflet-touch &:before,
+            &:after {
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                margin: auto;
+                width: 14px;
+                height: 2px;
+                background-color: #7a7a7a; // 48%
+                box-shadow: 0 1px #fff;
+                content: '';
+                }
 
-    &:active:before,
-    &:active:after {
-        background-color: #575757; // 34%
-    }
+            &:after {
+                width: 2px;
+                height: 14px;
+                }
 
-    .leaflet-disabled &:before,
-    .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:before,
-    .leaflet-disabled &:hover:after,
-    .leaflet-disabled &:active:before,
-    .leaflet-disabled &:active:after {
-        box-shadow: none;
-    }
-}
+            .no-touch &:hover:before,
+            .no-touch &:hover:after {
+                background-color: #616161; // 38%
+                }
 
-.dg-zoom__out {
-    position: absolute;
-    top: 40px;
-    right: 0;
-    left: 0;
-    margin: auto;
-    width: 22px;
-    height: 22px;
+            &:active:before,
+            &:active:after,
+            .no-touch &:active:before,
+            .no-touch &:active:after {
+                background-color: #575757; // 34%
+                }
 
-    &:after {
+            .leaflet-disabled &:before,
+            .leaflet-disabled &:after,
+            .no-touch .leaflet-disabled &:hover:before,
+            .no-touch .leaflet-disabled &:hover:after,
+            .leaflet-disabled &:active:before,
+            .leaflet-disabled &:active:after {
+                box-shadow: none;
+                }
+            }
+
+    .dg-zoom__out {
         position: absolute;
-        top: -1px;
+        top: 40px;
         right: 0;
         left: 0;
         margin: auto;
-        width: 12px;
-        height: 2px;
-        content: '';
-    }
-}
+        width: 22px;
+        height: 22px;
 
-.dg-zoom__button_type_out {
-    width: 22px;
-    height: 22px;
+        &:after {
+            position: absolute;
+            top: -1px;
+            right: 0;
+            left: 0;
+            margin: auto;
+            width: 12px;
+            height: 2px;
+            content: '';
+            }
+        }
+        .dg-zoom__button_type_out {
+            width: 22px;
+            height: 22px;
 
-    .leaflet-touch &:before {
-        top: -5px;
-        right: -19px;
-        bottom: -19px;
-        left: -19px;
-    }
+            .leaflet-touch &:before {
+                top: -5px;
+                right: -19px;
+                bottom: -19px;
+                left: -19px;
+                }
 
-    &:after {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        margin: auto;
-        width: 10px;
-        height: 2px;
-        background: #7a7a7a; // 48%
-        box-shadow: 0 1px #fff;
-        content: '';
-    }
+            &:after {
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                margin: auto;
+                width: 10px;
+                height: 2px;
+                background: #7a7a7a; // 48%
+                box-shadow: 0 1px #fff;
+                content: '';
+                }
 
-    &:hover:after {
-        background: #616161; // 38%
-    }
+            .no-touch &:hover:after {
+                background: #616161; // 38%
+                }
 
-    &:active:after {
-        background: #575757; // 34%
-    }
+            &:active:after,
+            .no-touch &:active:after {
+                background: #575757; // 34%
+                }
 
-    .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:after,
-    .leaflet-disabled &:active:after {
-        box-shadow: none;
-    }
-}
+            .leaflet-disabled &:after,
+            .no-touch .leaflet-disabled &:hover:after,
+            .leaflet-disabled &:active:after {
+                box-shadow: none;
+                }
+            }

--- a/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
@@ -1,135 +1,135 @@
 .dg-zoom {
     width: 40px;
     height: 74px;
+}
+
+.dg-zoom__in {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    .leaflet-touch &:before {
+        position: absolute;
+        top: -5px;
+        right: -10px;
+        bottom: 0;
+        left: -10px;
+        content: '';
     }
-    .dg-zoom__in {
+
+    &:after {
+        position: absolute;
+        right: 0;
+        bottom: -1px;
+        left: 0;
+        z-index: -1;
+        margin: auto;
+        width: 12px;
+        height: 2px;
+        box-shadow: 0 0 3px 2px rgba(0, 0, 0, .3);
+        content: '';
+    }
+}
+
+.dg-zoom__button_type_in {
+    &:before,
+    .leaflet-touch &:before,
+    &:after {
         position: absolute;
         top: 0;
+        right: 0;
+        bottom: 0;
         left: 0;
+        margin: auto;
+        width: 14px;
+        height: 2px;
+        background-color: #7a7a7a; // 48%
+        box-shadow: 0 1px #fff;
+        content: '';
+    }
 
-        .leaflet-touch &:before {
-            position: absolute;
-            top: -5px;
-            right: -10px;
-            bottom: 0;
-            left: -10px;
-            content: '';
-            }
+    &:after {
+        width: 2px;
+        height: 14px;
+    }
 
-        &:after {
-            position: absolute;
-            right: 0;
-            bottom: -1px;
-            left: 0;
-            z-index: -1;
-            margin: auto;
-            width: 12px;
-            height: 2px;
-            box-shadow: 0 0 3px 2px rgba(0,0,0,.3);
-            content: '';
-            }
-        }
-        .dg-zoom__button_type_in {
-            &:before,
-            .leaflet-touch &:before,
-            &:after {
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                margin: auto;
-                width: 14px;
-                height: 2px;
-                background-color: #7a7a7a; // 48%
-                box-shadow: 0 1px #fff;
-                content: '';
-                }
+    &:hover:before,
+    &:hover:after {
+        background-color: #616161; // 38%
+    }
 
-            &:after {
-                width: 2px;
-                height: 14px;
-                }
+    &:active:before,
+    &:active:after {
+        background-color: #575757; // 34%
+    }
 
-            .no-touch &:hover:before,
-            .no-touch &:hover:after {
-                background-color: #616161; // 38%
-                }
+    .leaflet-disabled &:before,
+    .leaflet-disabled &:after,
+    .leaflet-disabled &:hover:before,
+    .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:active:before,
+    .leaflet-disabled &:active:after {
+        box-shadow: none;
+    }
+}
 
-            &:active:before,
-            &:active:after,
-            .no-touch &:active:before,
-            .no-touch &:active:after {
-                background-color: #575757; // 34%
-                }
+.dg-zoom__out {
+    position: absolute;
+    top: 40px;
+    right: 0;
+    left: 0;
+    margin: auto;
+    width: 22px;
+    height: 22px;
 
-            .leaflet-disabled &:before,
-            .leaflet-disabled &:after,
-            .no-touch .leaflet-disabled &:hover:before,
-            .no-touch .leaflet-disabled &:hover:after,
-            .leaflet-disabled &:active:before,
-            .leaflet-disabled &:active:after {
-                box-shadow: none;
-                }
-            }
-
-    .dg-zoom__out {
+    &:after {
         position: absolute;
-        top: 40px;
+        top: -1px;
         right: 0;
         left: 0;
         margin: auto;
-        width: 22px;
-        height: 22px;
+        width: 12px;
+        height: 2px;
+        content: '';
+    }
+}
 
-        &:after {
-            position: absolute;
-            top: -1px;
-            right: 0;
-            left: 0;
-            margin: auto;
-            width: 12px;
-            height: 2px;
-            content: '';
-            }
-        }
-        .dg-zoom__button_type_out {
-            width: 22px;
-            height: 22px;
+.dg-zoom__button_type_out {
+    width: 22px;
+    height: 22px;
 
-            .leaflet-touch &:before {
-                top: -5px;
-                right: -19px;
-                bottom: -19px;
-                left: -19px;
-                }
+    .leaflet-touch &:before {
+        top: -5px;
+        right: -19px;
+        bottom: -19px;
+        left: -19px;
+    }
 
-            &:after {
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                margin: auto;
-                width: 10px;
-                height: 2px;
-                background: #7a7a7a; // 48%
-                box-shadow: 0 1px #fff;
-                content: '';
-                }
+    &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        width: 10px;
+        height: 2px;
+        background: #7a7a7a; // 48%
+        box-shadow: 0 1px #fff;
+        content: '';
+    }
 
-            .no-touch &:hover:after {
-                background: #616161; // 38%
-                }
+    &:hover:after {
+        background: #616161; // 38%
+    }
 
-            &:active:after,
-            .no-touch &:active:after {
-                background: #575757; // 34%
-                }
+    &:active:after {
+        background: #575757; // 34%
+    }
 
-            .leaflet-disabled &:after,
-            .no-touch .leaflet-disabled &:hover:after,
-            .leaflet-disabled &:active:after {
-                box-shadow: none;
-                }
-            }
+    .leaflet-disabled &:after,
+    .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:active:after {
+        box-shadow: none;
+    }
+}

--- a/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/basic/less/dg-zoom-control.less
@@ -51,22 +51,20 @@
                 height: 14px;
                 }
 
-            .no-touch &:hover:before,
-            .no-touch &:hover:after {
+            &:hover:before,
+            &:hover:after {
                 background-color: #616161; // 38%
                 }
 
             &:active:before,
-            &:active:after,
-            .no-touch &:active:before,
-            .no-touch &:active:after {
+            &:active:after {
                 background-color: #575757; // 34%
                 }
 
             .leaflet-disabled &:before,
             .leaflet-disabled &:after,
-            .no-touch .leaflet-disabled &:hover:before,
-            .no-touch .leaflet-disabled &:hover:after,
+            .leaflet-disabled &:hover:before,
+            .leaflet-disabled &:hover:after,
             .leaflet-disabled &:active:before,
             .leaflet-disabled &:active:after {
                 box-shadow: none;
@@ -118,17 +116,17 @@
                 content: '';
                 }
 
-            .no-touch &:hover:after {
+            &:hover:after {
                 background: #616161; // 38%
                 }
 
             &:active:after,
-            .no-touch &:active:after {
+            &:active:after {
                 background: #575757; // 34%
                 }
 
             .leaflet-disabled &:after,
-            .no-touch .leaflet-disabled &:hover:after,
+            .leaflet-disabled &:hover:after,
             .leaflet-disabled &:active:after {
                 box-shadow: none;
                 }

--- a/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
@@ -9,8 +9,8 @@
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:before,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:before,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
@@ -19,7 +19,7 @@
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
         }

--- a/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
@@ -1,26 +1,26 @@
 .dg-zoom__out {
-    box-shadow: 0 2px 3px 0 rgba(0, 0, 0, .3);
+    box-shadow: 0 2px 3px 0 rgba(0,0,0,.3);
 
     &:after {
         background-color: #3d3d3d; // 24%
+        }
     }
-}
 
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:before,
-    .leaflet-disabled &:hover:after,
+    .no-touch .leaflet-disabled &:hover:before,
+    .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
+        }
     }
-}
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:after,
+    .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
+        }
     }
-}

--- a/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/dark/less/dg-zoom-control.less
@@ -1,26 +1,26 @@
 .dg-zoom__out {
-    box-shadow: 0 2px 3px 0 rgba(0,0,0,.3);
+    box-shadow: 0 2px 3px 0 rgba(0, 0, 0, .3);
 
     &:after {
         background-color: #3d3d3d; // 24%
-        }
     }
+}
 
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:before,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:before,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
-        }
     }
+}
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #707070; // 44%
-        }
     }
+}

--- a/src/DGZoomControl/skin/light/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/light/less/dg-zoom-control.less
@@ -14,8 +14,8 @@
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:before,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:before,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
@@ -24,7 +24,7 @@
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
         }

--- a/src/DGZoomControl/skin/light/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/light/less/dg-zoom-control.less
@@ -1,31 +1,28 @@
-
 .dg-zoom__out {
-    box-shadow:
-        0 0 0 1px #fff,
-        0 2px 3px 0 rgba(0,0,0,.3);
+    box-shadow: 0 0 0 1px #fff, 0 2px 3px 0 rgba(0, 0, 0, .3);
 
     &:after {
         border: solid #fff;
         border-width: 0 1px;
         background-color: #f0f0f0; // 94%
-        }
     }
+}
 
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:before,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:before,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
-        }
     }
+}
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .no-touch .leaflet-disabled &:hover:after,
+    .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
-        }
     }
+}

--- a/src/DGZoomControl/skin/light/less/dg-zoom-control.less
+++ b/src/DGZoomControl/skin/light/less/dg-zoom-control.less
@@ -1,28 +1,31 @@
+
 .dg-zoom__out {
-    box-shadow: 0 0 0 1px #fff, 0 2px 3px 0 rgba(0, 0, 0, .3);
+    box-shadow:
+        0 0 0 1px #fff,
+        0 2px 3px 0 rgba(0,0,0,.3);
 
     &:after {
         border: solid #fff;
         border-width: 0 1px;
         background-color: #f0f0f0; // 94%
+        }
     }
-}
 
 .dg-zoom__button_type_in {
     .leaflet-disabled &:before,
     .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:before,
-    .leaflet-disabled &:hover:after,
+    .no-touch .leaflet-disabled &:hover:before,
+    .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:before,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
+        }
     }
-}
 
 .dg-zoom__button_type_out {
     .leaflet-disabled &:after,
-    .leaflet-disabled &:hover:after,
+    .no-touch .leaflet-disabled &:hover:after,
     .leaflet-disabled &:active:after {
         background-color: #999; // 60%
+        }
     }
-}


### PR DESCRIPTION
Выпилил класс `no-touch`. Он использовался для идентификации тач устройств, однако с недавних пор обычные устройства стали идентифицироваться как тач (https://github.com/Leaflet/Leaflet/issues/5266). В результате перестали работать ховер эффекты. С этим PR ховер эффекты работают. На своём андройде не заметил из-за этого никаких проблем.