### PR TITLE
Update eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": "eslint:recommended",
   "rules": {
     "eqeqeq": 0,
     "camelcase": 2,
@@ -22,7 +23,7 @@
     "key-spacing": 0,
     "no-shadow": 0
   },
-    "globals": {
+  "globals": {
     "dust": true,
     "DG": true,
     "L": true,
@@ -30,7 +31,9 @@
     "module": false,
     "define": false
   },
-    "env": {
-    "browser": true
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,8 @@
     "no-multi-spaces": 0,
     "strict": 0,
     "key-spacing": 0,
-    "no-shadow": 0
+    "no-shadow": 0,
+    "no-console": 1
   },
   "globals": {
     "dust": true,

--- a/gulp/tasks/concatScripts.js
+++ b/gulp/tasks/concatScripts.js
@@ -3,7 +3,6 @@ var streamqueue = require('streamqueue');
 var concat = require('gulp-concat');
 var footer = require('gulp-footer');
 var es = require('event-stream');
-var file = require('gulp-file');
 var gulpif = require('gulp-if');
 var util = require('gulp-util');
 var map = require('map-stream');

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "gulp-derequire": "^2.1.0",
     "gulp-dust": "^3.0.0",
     "gulp-eslint": "^3.0.1",
-    "gulp-file": "0.2.0",
     "gulp-flatten": "0.2.0",
     "gulp-footer": "^1.0.5",
     "gulp-git": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-derequire": "^2.1.0",
     "gulp-dust": "^3.0.0",
-    "gulp-eslint": "^2.0.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-file": "0.2.0",
     "gulp-flatten": "0.2.0",
     "gulp-footer": "^1.0.5",

--- a/src/DGPopup/src/DGPopup.js
+++ b/src/DGPopup/src/DGPopup.js
@@ -608,9 +608,8 @@ require('../../../vendors/baron');
         _toggleTouchEvents: function (on) {
             var switcher = on ? 'off' : 'on';
 
-            DG.DomEvent
-                [switcher](this._contentNode, 'touchmove', this._onMove, this)
-                [switcher](this._contentNode, 'touchend', this._onEnd, this);
+            DG.DomEvent[switcher](this._contentNode, 'touchmove', this._onMove, this);
+            DG.DomEvent[switcher](this._contentNode, 'touchend', this._onEnd, this);
         }
 
     });


### PR DESCRIPTION
1. Обновил eslint до 3й версии
2. Добавил наследование правил с `eslint:recommended`
3. Удалил пакет `gulp-file` - остался с давних пор, был найден линтером
4. В файле `src/DGPopup/src/DGPopup.js` внёс небольшое стилистическое изменение, чтобы линтер не ругался