### PR TITLE
Fix js files stats

### DIFF
--- a/gulp/tasks/buildScripts.js
+++ b/gulp/tasks/buildScripts.js
@@ -1,4 +1,5 @@
 var config = require('../../app/config.js');
+var stat = require('../util/stat');
 var source = require('vinyl-source-stream');
 var derequire = require('gulp-derequire');
 var browserify = require('browserify');
@@ -10,6 +11,7 @@ var gulpif = require('gulp-if');
 var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
+var map = require('map-stream');
 
 gulp.task('buildScripts', ['concatScripts'], function () {
     var isCustom = util.env.pkg || util.env.skin;
@@ -46,6 +48,7 @@ gulp.task('buildScripts', ['concatScripts'], function () {
             .pipe(derequire())
             .pipe(gulpif(util.env.release, uglify()))
             .pipe(gulpif(util.env.release, header(config.copyright)))
+            .pipe(map(stat.save))
             .pipe(gulp.dest('dist/js/'));
     }).reduce(function (prev, curr) {
         return es.merge(prev, curr);

--- a/gulp/tasks/concatScripts.js
+++ b/gulp/tasks/concatScripts.js
@@ -6,7 +6,6 @@ var es = require('event-stream');
 var file = require('gulp-file');
 var gulpif = require('gulp-if');
 var util = require('gulp-util');
-var map = require('map-stream');
 var gulp = require('gulp');
 
 var config = require('../../app/config.js');
@@ -15,7 +14,6 @@ var deps = require('../deps')(config);
 var templateStream = require('../util/templateStream');
 var projectList = require('../util/projectList');
 var error = require('../util/error');
-var stat = require('../util/stat');
 
 var dependencies = util.env['project-list'] !== false ? ['loadProjectList', 'buildLeaflet'] : ['buildLeaflet'];
 
@@ -57,7 +55,6 @@ gulp.task('concatScripts', dependencies, function () {
         }
 
         return stream
-            .pipe(map(stat.save))
             .pipe(gulpif(!util.env.release, sourcemaps.write()))
             .pipe(gulp.dest('gulp/tmp/js'));
     }).reduce(function (prev, curr) {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "optimist": "^0.6.1",
     "phantomjs-prebuilt": "2.1.11",
     "pixelsmith": "^2.1.0",
-    "pretty-bytes": "^3.0.1",
+    "pretty-bytes": "^4.0.2",
     "prosthetic-hand": "^1.3.0",
     "request": "^2.70.0",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
Размер собранных js файлов вычислялся некорректно (мягко говоря). Теперь статистика соответствует реальному размеру файлов на диске. Результаты:

#### Команда `gulp build`:

| Файл | Старая статистика | Новая статистика |
|---|---|---|
| script.basic.js | 167.59 kB | 1.61 MB |
| script.full.js | 441.13 kB | 2.32 MB |

#### Команда `gulp build --release`:

| Файл | Старая статистика | Новая статистика |
|---|---|---|
| script.basic.js | 167.59 kB | 278 kB |
| script.full.js | 441.13 kB | 413 kB |


