### PR TITLE
Listen poi events from overlay layer too

### DIFF
--- a/src/DGMeta/src/DGMeta.Layer.js
+++ b/src/DGMeta/src/DGMeta.Layer.js
@@ -59,10 +59,12 @@ DG.Meta.Layer = DG.Layer.extend({
     },
 
     _addDomEvents: function () {
+        DG.DomEvent.on(this._map.getPane('overlayPane'), this._domEvents, this);
         DG.DomEvent.on(this._map.getPane('tilePane'), this._domEvents, this);
     },
 
     _removeDomEvents: function () {
+        DG.DomEvent.off(this._map.getPane('overlayPane'), this._domEvents, this);
         DG.DomEvent.off(this._map.getPane('tilePane'), this._domEvents, this);
     },
 


### PR DESCRIPTION
Если отрисовать геометрию на канвасе, то у нас не работают ховеры на пои

Пример для воспроизведения:
```js
DG.then(function() {
  var map = DG.map('map', {
    center: [54.980156831455, 82.897440725094],
    zoom: 13
  });
  var myRenderer = L.canvas({ padding: 0.5 });
  L.circle( [54.980156831455, 82.897440725094], 200, { renderer: myRenderer } ).addTo(map);
});
```

Для фикса добавил еще отслеживаю еще события на overlaypane