### PR TITLE
add custom config

### DIFF
--- a/app/loader.js
+++ b/app/loader.js
@@ -199,6 +199,10 @@
 
     function extendConfig() {
         DG.extend(DG.config, __LOCAL_CONFIG__);
+
+        if (DG.customConfig) {
+            DG.extend(DG.config, DG.customConfig);
+        }
     }
 
     function prepareForInit() {


### PR DESCRIPTION
Added ability to override config values before calling `DG.then`. Usage example:

```js
DG.customConfig = {
    webApiKey: 'customkey',
    geoclickerCatalogApiKey: 'customkey',
    webApiServer: '//catalog2.api.2gis.ru'
};

DG.then(function() {
    var map = DG.map(...);
    ...
});
```