### PR TITLE
Simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: node_js
 sudo: false
 node_js:
   - '6'
-before_install:
-  - npm install -g gulp
-install:
-  - npm install
-script:
-  - gulp test
 after_success: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 notifications:
   slack:


### PR DESCRIPTION
Упростил конфиг тревиса:

- `npm install -g gulp` гальп устанавливается локально, поэтому оно не нужно
- `npm install` вызывается автоматически
- `gulp test` тревис автоматически вызывает `npm test`, у нас там указано `gulp test`