### PR TITLE
Linter updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,16 +25,13 @@
     "no-console": 1
   },
   "globals": {
-    "dust": true,
     "DG": true,
     "L": true,
     "baron": true,
-    "module": false,
-    "define": false,
     "Promise": true
   },
   "env": {
     "browser": true,
-    "commonjs": true
+    "node": true
   }
 }

--- a/app/config.js
+++ b/app/config.js
@@ -67,7 +67,7 @@ function updateLoaderVersion(done) {
         loaderFileName = config.loader.name,
         version = require('../package.json').version;
 
-    fs.readFile(loaderPath + '/' + loaderFileName, {encoding: 'utf8'}, function (err, loaderContent) {
+    fs.readFile(loaderPath + '/' + loaderFileName, {encoding: 'utf8'}, function(err, loaderContent) {
         if (err) { throw err; }
 
         console.log('Set version of stat files: ' + version);

--- a/app/index.js
+++ b/app/index.js
@@ -78,7 +78,7 @@ function loadDir(dirPath) {
 
 // Load and serve JS files
 var jsFiles = loadDir('./dist/js');
-app.get('/js', function (req, res) {
+app.get('/js', function(req, res) {
     var params = getParams(req);
     var fileName = 'script.' + params.pkg + '.js';
 
@@ -91,7 +91,7 @@ app.get('/js', function (req, res) {
 
 // Load and serve CSS files
 var cssFiles = loadDir('./dist/css');
-app.get('/css', function (req, res) {
+app.get('/css', function(req, res) {
     var params = getParams(req);
 
     var fileName = 'styles.' +
@@ -116,11 +116,11 @@ var port = config.appConfig.port;
 
 if (cluster.isMaster) {
     cluster
-        .on('disconnect', function (worker) {
+        .on('disconnect', function(worker) {
             console.log('PID #' + worker.process.pid + ' died. spawning a new process...');
             cluster.fork();
         })
-        .on('fork', function (worker) {
+        .on('fork', function(worker) {
             console.log('PID #' + worker.process.pid + ' started!');
         });
 
@@ -130,7 +130,7 @@ if (cluster.isMaster) {
         cluster.fork({number: i});
     }
 } else {
-    app.listen(port, host, function () {
+    app.listen(port, host, function() {
         if (process.env.number == 0) {
             console.log(clc.green('Maps API 2.0 server listening on ' + (host ? host + ':' : '') + port));
         }

--- a/app/loader.js
+++ b/app/loader.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
     'use strict';
 
     var isJSRequested = false;
@@ -44,7 +44,7 @@
         script.setAttribute('type', 'text/javascript');
         script.setAttribute('src', baseURL + '/js/' + qs);
 
-        script.onerror = function (evt) {
+        script.onerror = function(evt) {
             runRejects(evt);
         };
 
@@ -122,13 +122,13 @@
         var style = document.createElement('style');
         style.type = 'text/css';
 
-        return new Promise(function (resolve, reject) {
+        return new Promise(function(resolve, reject) {
             DG.ajax(url, {
                 type: 'get',
 
                 dataType: 'html',
 
-                success: function (data) {
+                success: function(data) {
                     var head = document.getElementsByTagName('head')[0];
 
                     // Replace urls in CSS in case local config was changed
@@ -156,7 +156,7 @@
                     resolve();
                 },
 
-                error: function () {
+                error: function() {
                     reject();
                 }
             });
@@ -168,7 +168,7 @@
             DG.config.webApiServer + '/' +
             DG.config.webApiVersion + '/region/list';
 
-        return new Promise(function (resolve) {
+        return new Promise(function(resolve) {
             DG.ajax(url, {
                 type: DG.ajax.corsSupport ? 'get' : 'jsonp',
 
@@ -180,7 +180,7 @@
 
                 timeout: DG.config.loadProjectListTimeout,
 
-                success: function (data) {
+                success: function(data) {
                     var result = data.result;
 
                     if (result && result.items && result.items.length) {
@@ -190,7 +190,7 @@
                     resolve();
                 },
 
-                error: function (err) {
+                error: function(err) {
                     resolve();
                 }
             });
@@ -219,7 +219,7 @@
 
     function runRejects() {
         for (var i = 0, l = rejects.length; i < l; i++) {
-            if (typeof rejects[i] == 'function') {
+            if (typeof rejects[i] === 'function') {
                 rejects[i]();
             }
         }
@@ -237,7 +237,7 @@
         version: version
     };
 
-    var loaderDgThen = window.DG.then = function (resolve, reject) {
+    var loaderDgThen = window.DG.then = function(resolve, reject) {
         if (DG.then !== loaderDgThen) {
             return DG.then(resolve, reject);
         }

--- a/gulp/deps/index.js
+++ b/gulp/deps/index.js
@@ -3,7 +3,7 @@ var glob = require('glob');
 var path = require('path');
 var imageSize = require('image-size');
 
-var init = function (config) {
+var init = function(config) {
     var packages = config.packages;
 
     // Generates a list of modules by pkg
@@ -14,7 +14,7 @@ var init = function (config) {
         var modulesListRes = [];
         var loadedModules = {};
 
-        if (typeof pkg == 'boolean') {
+        if (typeof pkg === 'boolean') {
             throw new Error('pkg param can\'t be empty');
         }
 
@@ -23,7 +23,7 @@ var init = function (config) {
             modulesListOrig = packages[pkg].modules;
 
             // Modules list (example: 'Core,JSONP,TileLayer')
-        } else if (pkg && pkg.indexOf(',') != -1) {
+        } else if (pkg && pkg.indexOf(',') !== -1) {
             modulesListOrig = pkg.split(',');
 
             // Modules single (example: 'Core')
@@ -66,19 +66,19 @@ var init = function (config) {
         var isLeaflet = options.source === 'leaflet';
 
         return getModulesList(options.pkg, modules, isLeaflet)
-            .map(function (name) {
+            .map(function(name) {
                 return modules[name];
             })
-            .map(function (module) {
+            .map(function(module) {
                 return module.src;
             })
-            .reduce(function (array, items) {
+            .reduce(function(array, items) {
                 return array.concat(items);
             })
-            .filter(function (item, index, list) { //filter dublicates
+            .filter(function(item, index, list) { //filter dublicates
                 return list.indexOf(item) == index;
             })
-            .map(function (file) {
+            .map(function(file) {
                 return sourcePath + file;
             });
     }
@@ -92,14 +92,14 @@ var init = function (config) {
         var skin = options.skin || config.appConfig.defaultSkin;
 
         return getModulesList(options.pkg, modules)
-            .map(function (name) {
+            .map(function(name) {
                 return modules[name];
             })
-            .map(function (module) {
+            .map(function(module) {
                 return module[options.type || 'less'];
             })
             .filter(Boolean)
-            .reduce(function (array, item) {
+            .reduce(function(array, item) {
                 var items = [];
 
                 if (!options.excludeBaseCss && item.all) {
@@ -112,20 +112,20 @@ var init = function (config) {
 
                 return array.concat(items);
             }, [])
-            .reduce(function (array, items) {
+            .reduce(function(array, items) {
                 return array.concat(items);
             }, [])
-            .reduce(function (array, item) { // if css have skin, we add basic theme
-                if (item.indexOf('{skin}') != -1) {
+            .reduce(function(array, item) { // if css have skin, we add basic theme
+                if (item.indexOf('{skin}') !== -1) {
                     array.push(item.replace('{skin}', 'basic'));
                 }
 
                 return array.concat(item);
             }, [])
-            .map(function (file) { // add selected theme
+            .map(function(file) { // add selected theme
                 return file.replace('{skin}', skin);
             })
-            .map(function (file) {
+            .map(function(file) {
                 return sourcePath + file;
             })
             .filter(fs.existsSync);
@@ -138,7 +138,7 @@ var init = function (config) {
         var modules = source.deps;
 
         return getModulesList(options.pkg, modules)
-            .map(function (name) {
+            .map(function(name) {
                 return 'src/' + name + '/**/img/**/*.{png,gif,jpg,jpeg,svg}';
             });
     }
@@ -150,14 +150,14 @@ var init = function (config) {
         var header = '';
 
         if (options.variables) {
-            Object.keys(options.variables).forEach(function (varableName) {
+            Object.keys(options.variables).forEach(function(varableName) {
                 header = header + '\n' + '@' + varableName + ': ' + options.variables[varableName] + ';';
             });
         }
 
         var importsBase = '';
 
-        if (typeof options.importsBase == 'string' && options.importsBase.length) {
+        if (typeof options.importsBase === 'string' && options.importsBase.length) {
             importsBase = options.importsBase.replace(/\/*$/, '/');
         }
 
@@ -178,10 +178,10 @@ var init = function (config) {
         var skinsDirectories = glob.sync(__dirname + '/../../src/**/skin/*');
         var skins = [];
 
-        skinsDirectories.forEach(function (directory) {
+        skinsDirectories.forEach(function(directory) {
             var skinName = path.basename(directory);
 
-            if (skins.indexOf(skinName) == -1) {
+            if (skins.indexOf(skinName) === -1) {
                 skins.push(skinName);
             }
         });
@@ -196,8 +196,8 @@ var init = function (config) {
         var perSkinStats = {};
         var imgModulesGlobs = getImgGlob();
 
-        imgModulesGlobs.forEach(function (imgGlob) {
-            glob.sync(imgGlob).forEach(function (imagePath) {
+        imgModulesGlobs.forEach(function(imgGlob) {
+            glob.sync(imgGlob).forEach(function(imagePath) {
                 var skinName = imagePath.split('/')[3];
                 var extname = path.extname(imagePath);
                 var name = path.basename(imagePath, extname);
@@ -237,7 +237,7 @@ var init = function (config) {
 
         var perSkinStats = {};
 
-        skins.forEach(function (skinName) {
+        skins.forEach(function(skinName) {
             var stats = {};
 
             var statsFilePath = __dirname + '/../tmp/less/images-usage-statistics.' + skinName + '.less';
@@ -251,8 +251,8 @@ var init = function (config) {
             stats.notRepeatableNotSprited = rawStats.notRepeatableNotSprited.split(',');
             // Repeatable images can be used as no-repeatable images,
             // so we should exclude repeatable images from no-repeatable images list
-            stats.notRepeatableSprited = rawStats.notRepeatableSprited.split(',').filter(function (name) {
-                return stats.repeatable.indexOf(name) == -1;
+            stats.notRepeatableSprited = rawStats.notRepeatableSprited.split(',').filter(function(name) {
+                return stats.repeatable.indexOf(name) === -1;
             });
 
             perSkinStats[skinName] = stats;
@@ -279,6 +279,6 @@ var init = function (config) {
 };
 
 
-if (typeof module != 'undefined' && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
     module.exports = init;
 }

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -4,7 +4,7 @@ var runSequence = require('run-sequence');
 var util = require('gulp-util');
 var gulp = require('gulp');
 
-gulp.task('build', function (cb) {
+gulp.task('build', function(cb) {
     if (util.env.npm) {
         // Disable local config for npm builds
         config.appConfig = config.mainConfig;
@@ -20,7 +20,7 @@ gulp.task('build', function (cb) {
         'copyAssets',
         'copyIndexPage',
         'hooks'
-    ], function () {
+    ], function() {
         buildEnd();
         cb();
     });

--- a/gulp/tasks/buildLeaflet.js
+++ b/gulp/tasks/buildLeaflet.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 var config = require('../../app/config.js');
 var deps = require('../deps')(config);
 
-gulp.task('buildLeaflet', function () {
+gulp.task('buildLeaflet', function() {
     return gulp.src(deps.getJSFiles({source: 'leaflet'}))
         .pipe(concat('leaflet-src.js'))
         .pipe(gulp.dest('node_modules/leaflet/dist/'));

--- a/gulp/tasks/buildScripts.js
+++ b/gulp/tasks/buildScripts.js
@@ -13,7 +13,7 @@ var gulp = require('gulp');
 var path = require('path');
 var map = require('map-stream');
 
-gulp.task('buildScripts', ['concatScripts'], function () {
+gulp.task('buildScripts', ['concatScripts'], function() {
     var isCustom = util.env.pkg || util.env.skin;
     var packages;
 
@@ -25,7 +25,7 @@ gulp.task('buildScripts', ['concatScripts'], function () {
         packages = Object.keys(config.packages);
     }
 
-    return packages.map(function (pkg) {
+    return packages.map(function(pkg) {
         var name = 'script.' + (!isCustom ? pkg + '.' : '') + 'js';
         var src = path.join('gulp', 'tmp', 'js', name);
 
@@ -50,7 +50,7 @@ gulp.task('buildScripts', ['concatScripts'], function () {
             .pipe(gulpif(util.env.release, header(config.copyright)))
             .pipe(map(stat.save))
             .pipe(gulp.dest('dist/js/'));
-    }).reduce(function (prev, curr) {
+    }).reduce(function(prev, curr) {
         return es.merge(prev, curr);
     });
 });

--- a/gulp/tasks/buildStyles.js
+++ b/gulp/tasks/buildStyles.js
@@ -6,6 +6,6 @@ gulp.task('buildStyles', [
     'collectImagesStats',
     'generateSprites',
     'imageMinify'
-], function () {
+], function() {
     return destCSS();
 });

--- a/gulp/tasks/buildTest.js
+++ b/gulp/tasks/buildTest.js
@@ -3,7 +3,7 @@ var gulp = require('gulp');
 
 var buildEnd = require('../util/buildEnd.js');
 
-gulp.task('buildTest', function (cb) {
+gulp.task('buildTest', function(cb) {
     global.isTestBuild = true;
 
     runSequence('clean', [
@@ -13,7 +13,7 @@ gulp.task('buildTest', function (cb) {
         'loader',
         'copyAssets',
         'copyIndexPage'
-    ], function () {
+    ], function() {
         buildEnd();
         cb();
     });

--- a/gulp/tasks/buildTestFunc.js
+++ b/gulp/tasks/buildTestFunc.js
@@ -3,7 +3,7 @@ var gulp = require('gulp');
 
 var buildEnd = require('../util/buildEnd.js');
 
-gulp.task('buildTestFunc', function (cb) {
+gulp.task('buildTestFunc', function(cb) {
     global.isTestBuild = true;
 
     runSequence('clean', [
@@ -11,7 +11,7 @@ gulp.task('buildTestFunc', function (cb) {
         'buildStyles',
         'doc',
         'copyPrivateAssets'
-    ], function () {
+    ], function() {
         buildEnd();
         cb();
     });

--- a/gulp/tasks/bump.js
+++ b/gulp/tasks/bump.js
@@ -2,7 +2,7 @@ var bump = require('gulp-bump');
 var util = require('gulp-util');
 var gulp = require('gulp');
 
-gulp.task('bump', function () {
+gulp.task('bump', function() {
     return gulp.src('package.json')
         .pipe(bump(util.env))
         .pipe(gulp.dest('./'));

--- a/gulp/tasks/bumpLoader.js
+++ b/gulp/tasks/bumpLoader.js
@@ -2,6 +2,6 @@ var gulp = require('gulp');
 
 var config = require('../../app/config');
 
-gulp.task('bumpLoader', ['bump'], function (done) {
+gulp.task('bumpLoader', ['bump'], function(done) {
     config.updateLoaderVersion(done);
 });

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var del = require('del');
 
-gulp.task('clean', function () {
+gulp.task('clean', function() {
     return del(['dist', 'gulp/tmp']);
 });

--- a/gulp/tasks/collectImagesStats.js
+++ b/gulp/tasks/collectImagesStats.js
@@ -5,14 +5,14 @@ var mkdirp = require('mkdirp');
 var config = require('../../app/config');
 var deps = require('../deps')(config);
 
-gulp.task('collectImagesStats', ['copyImg'], function (cb) {
+gulp.task('collectImagesStats', ['copyImg'], function(cb) {
     var skins = deps.getSkinsList();
     var imagesStatsPerSkin = deps.getImagesFilesStats(skins);
 
     mkdirp.sync('./gulp/tmp');
     mkdirp.sync('./gulp/tmp/less');
 
-    skins.forEach(function (skinName) {
+    skins.forEach(function(skinName) {
         var skinImagesFilesStats = imagesStatsPerSkin[skinName];
 
         var statisticsObject;
@@ -29,7 +29,7 @@ gulp.task('collectImagesStats', ['copyImg'], function (cb) {
             statisticsObject = skinImagesFilesStats[imageName];
             originalImageStatisticObject = skinImagesFilesStats[originalImageName];
 
-            imageExtension = (typeof statisticsObject.extension == 'undefined') ? 'svg' : statisticsObject.extension;
+            imageExtension = (typeof statisticsObject.extension === 'undefined') ? 'svg' : statisticsObject.extension;
 
             statisticsString += '.imageData(\'' + imageName + '\') { ' +
                 '@filename: \'' + imageName + '\'; ' +

--- a/gulp/tasks/collectImagesUsageStats.js
+++ b/gulp/tasks/collectImagesUsageStats.js
@@ -10,18 +10,18 @@ var error = require('../util/error');
 var config = require('../../app/config');
 var deps = require('../deps')(config);
 
-gulp.task('collectImagesUsageStats', function () {
+gulp.task('collectImagesUsageStats', function() {
     var skins = deps.getSkinsList();
 
     var imagesBasePath = path.resolve(__dirname + '/../../dist/img');
 
-    var statisticsStreams = skins.map(function (skinName) {
+    var statisticsStreams = skins.map(function(skinName) {
         var skinLessFiles = glob.sync('./src/**/' + skinName + '/less/*.less');
 
         skinLessFiles.unshift('./src/less/mixins.images-usage-statistics.less');
         skinLessFiles.unshift('./src/less/mixins.ie8.less');
 
-        skinLessFiles = skinLessFiles.map(function (lessFilePath) {
+        skinLessFiles = skinLessFiles.map(function(lessFilePath) {
             return lessFilePath + ':reference';
         });
 

--- a/gulp/tasks/commitFiles.js
+++ b/gulp/tasks/commitFiles.js
@@ -1,7 +1,7 @@
 var git = require('gulp-git');
 var gulp = require('gulp');
 
-gulp.task('commitFiles', ['bumpLoader'], function () {
+gulp.task('commitFiles', ['bumpLoader'], function() {
     var pkg = require('./package.json');
 
     return gulp.src('')

--- a/gulp/tasks/concatScripts.js
+++ b/gulp/tasks/concatScripts.js
@@ -16,11 +16,11 @@ var error = require('../util/error');
 
 var dependencies = util.env['project-list'] !== false ? ['loadProjectList', 'buildLeaflet'] : ['buildLeaflet'];
 
-function getStyleRequireStatement(package, skin) {
-    return `require('../../../dist/css/styles.${package}.${skin}.css');`;
+function getStyleRequireStatement(pack, skin) {
+    return 'require("../../../dist/css/styles.' + pack + '.' + skin + '.css");';
 }
 
-gulp.task('concatScripts', dependencies, function () {
+gulp.task('concatScripts', dependencies, function() {
     var isCustom = util.env.pkg || util.env.skin;
     var packages;
 
@@ -37,7 +37,7 @@ gulp.task('concatScripts', dependencies, function () {
         config.appConfig.tileServer = '';
     }
 
-    return packages.map(function (pkg) {
+    return packages.map(function(pkg) {
         var stream = streamqueue(
                 {objectMode: true},
                 gulp.src(deps.getJSFiles({pkg: pkg}), {base: '.'}),
@@ -56,7 +56,7 @@ gulp.task('concatScripts', dependencies, function () {
         return stream
             .pipe(gulpif(!util.env.release, sourcemaps.write()))
             .pipe(gulp.dest('gulp/tmp/js'));
-    }).reduce(function (prev, curr) {
+    }).reduce(function(prev, curr) {
         return es.merge(prev, curr);
     });
 });

--- a/gulp/tasks/copyAssets.js
+++ b/gulp/tasks/copyAssets.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var error = require('../util/error');
 
-gulp.task('copyAssets', function () {
+gulp.task('copyAssets', function() {
     return gulp.src(['assets/**/*'])
         .pipe(error.handle())
         .pipe(gulp.dest('dist'));

--- a/gulp/tasks/copyImg.js
+++ b/gulp/tasks/copyImg.js
@@ -6,10 +6,10 @@ var error = require('../util/error');
 var config = require('../../app/config');
 var deps = require('../deps')(config);
 
-gulp.task('copyImg', function () {
+gulp.task('copyImg', function() {
     return gulp.src(deps.getImgGlob(util.env))
         .pipe(error.handle())
-        .pipe(rename(function (p) {
+        .pipe(rename(function(p) {
             p.dirname = '';
         }))
         .pipe(gulp.dest('dist/img'));

--- a/gulp/tasks/copyIndexPage.js
+++ b/gulp/tasks/copyIndexPage.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var error = require('../util/error');
 
-gulp.task('copyIndexPage', function () {
+gulp.task('copyIndexPage', function() {
     return gulp.src(['app/index.html'])
         .pipe(error.handle())
         .pipe(gulp.dest('dist'));

--- a/gulp/tasks/dev.js
+++ b/gulp/tasks/dev.js
@@ -1,6 +1,6 @@
 var runSequence = require('run-sequence');
 var gulp = require('gulp');
 
-gulp.task('dev', function (cb) {
+gulp.task('dev', function(cb) {
     runSequence('build', 'server', 'watch', cb);
 });

--- a/gulp/tasks/doc.js
+++ b/gulp/tasks/doc.js
@@ -3,7 +3,7 @@ var gulp = require('gulp');
 var gendoc = require('../util/gendoc');
 var config = require('../../app/config');
 
-gulp.task('doc', function () {
+gulp.task('doc', function() {
     var doc = config.doc;
 
     gendoc.generateDocumentation(doc.menu, doc.input, doc.output);

--- a/gulp/tasks/generateSprites.js
+++ b/gulp/tasks/generateSprites.js
@@ -8,11 +8,11 @@ var deps = require('../deps')(config);
 
 gulp.task('generateSprites', [
     'collectImagesUsageStats'
-], function (cb) {
+], function(cb) {
     var skins = deps.getSkinsList();
     var stats = deps.getImagesUsageStats(skins);
 
-    var statisticsStreams = skins.map(function (skinName) {
+    var statisticsStreams = skins.map(function(skinName) {
         // Adds comma to make glob’s {} working properly,
         // even there is only one should be excluded
         var filesToExclude = stats[skinName].repeatable.join(',') + ',' +

--- a/gulp/tasks/help.js
+++ b/gulp/tasks/help.js
@@ -1,7 +1,7 @@
 var util = require('gulp-util');
 var gulp = require('gulp');
 
-gulp.task('help', function () {
+gulp.task('help', function() {
     util.log('Tasks list:');
     util.log('gulp lint        # Check JS files for errors with ESLint');
     util.log('gulp build       # Lint, combine and minify source files, update doc, copy assets');

--- a/gulp/tasks/hooks.js
+++ b/gulp/tasks/hooks.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 
-gulp.task('hooks', function () {
+gulp.task('hooks', function() {
     return gulp.src('hooks/pre-push')
         .pipe(gulp.dest('.git/hooks'));
 });

--- a/gulp/tasks/imageMinify.js
+++ b/gulp/tasks/imageMinify.js
@@ -7,7 +7,7 @@ gulp.task('imageMinify', [
     'copyAssets',
     'copyImg',
     'generateSprites'
-], function () {
+], function() {
     return gulp.src('dist/img/**/*.{png,gif,jpg,jpeg}')
         .pipe(gulpif(util.env.release, imagemin()))
         .pipe(gulp.dest('dist/img'));

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -1,4 +1,3 @@
-
 var gulp = require('gulp');
 
 gulp.task('lint', ['lintJS', 'lintCSS']);

--- a/gulp/tasks/lintCSS.js
+++ b/gulp/tasks/lintCSS.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 var csslint = require('../util/csslint/gulp-csslint');
 var error = require('../util/error');
 
-gulp.task('lintCSS', ['buildStyles'], function () {
+gulp.task('lintCSS', ['buildStyles'], function() {
     return gulp.src('dist/css/**.css')
         .pipe(error.handle())
         .pipe(csslint({

--- a/gulp/tasks/lintJS.js
+++ b/gulp/tasks/lintJS.js
@@ -3,7 +3,7 @@ var gulp = require('gulp');
 
 var error = require('../util/error');
 
-gulp.task('lintJS', function () {
+gulp.task('lintJS', function() {
     return gulp.src('src/**/src/**/*.js')
         .pipe(error.handle())
         .pipe(eslint())

--- a/gulp/tasks/lintJS.js
+++ b/gulp/tasks/lintJS.js
@@ -7,5 +7,6 @@ gulp.task('lintJS', function () {
     return gulp.src('src/**/src/**/*.js')
         .pipe(error.handle())
         .pipe(eslint())
-        .pipe(eslint.format());
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError());
 });

--- a/gulp/tasks/loadProjectList.js
+++ b/gulp/tasks/loadProjectList.js
@@ -6,7 +6,7 @@ var projectList = require('../util/projectList');
 var config = require('../../app/config.js');
 var errorNotifier = require('../util/error');
 
-gulp.task('loadProjectList', function (cb) {
+gulp.task('loadProjectList', function(cb) {
     if (projectList.get()) {
         return cb();
     }
@@ -28,7 +28,7 @@ gulp.task('loadProjectList', function (cb) {
 
     var url = protocol + apiServer + '/' + apiVersion + '/region/list?key=' + apiKey + '&fields=' + fields;
 
-    request(url, function (err, res, body) {
+    request(url, function(err, res, body) {
         if (err) {
             var error = new util.PluginError({
                 plugin: 'loadProjectList',

--- a/gulp/tasks/loader.js
+++ b/gulp/tasks/loader.js
@@ -7,7 +7,7 @@ var replace = require('gulp-replace');
 var error = require('../util/error');
 var config = require('../../app/config.js');
 
-gulp.task('loader', function () {
+gulp.task('loader', function() {
     var originalBaseUrl = config.appConfig.protocol + config.appConfig.baseUrl;
 
     gulp.src('app/loader.js')

--- a/gulp/tasks/rebuildStyles.js
+++ b/gulp/tasks/rebuildStyles.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var destCSS = require('../util/destCSS');
 
-gulp.task('rebuildStyles', function () {
+gulp.task('rebuildStyles', function() {
     return destCSS();
 });

--- a/gulp/tasks/release.js
+++ b/gulp/tasks/release.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var git = require('gulp-git');
 
-gulp.task('release', ['commitFiles'], function (done) {
+gulp.task('release', ['commitFiles'], function(done) {
     var pkg = require('./package.json');
     var v = pkg.version;
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -5,10 +5,7 @@ var path = require('path');
 var glob = require('glob');
 var _ = require('lodash');
 
-var error = require('../util/error');
 var test = require('../../test/test');
-var config = require('../../app/config.js');
-var deps = require('../deps')(config);
 var excludedTests = require('../../test/excludedTests.js') || [];
 
 var isTestDebug = util.env.d || util.env.debug;
@@ -16,7 +13,7 @@ var testRequirements = isTestDebug ? [] : ['buildTest'];
 var itemInChunk = util.env['items-in-chunk'] || 10;
 var multipleChunks = util.env['multiple-chunks'] || false;
 
-gulp.task('test', testRequirements, function (done) {
+gulp.task('test', testRequirements, function(done) {
     var cliOptions = _.cloneDeep(util.env);
     var modulesToTest = [];
     var currentChunk = 0;
@@ -25,8 +22,8 @@ gulp.task('test', testRequirements, function (done) {
         'dist/js/script.full.js',
         'node_modules/leaflet/spec/after.js',
         'node_modules/happen/happen.js',
-        "node_modules/prosthetic-hand/dist/prosthetic-hand.js",
-        "node_modules/leaflet/spec/suites/SpecHelper.js",
+        'node_modules/prosthetic-hand/dist/prosthetic-hand.js',
+        'node_modules/leaflet/spec/suites/SpecHelper.js',
         'node_modules/mock-geolocation/dist/geolocate.js',
         'test/after.js'
     ];
@@ -42,7 +39,7 @@ gulp.task('test', testRequirements, function (done) {
     var modulesToTestSourceList = [];
 
     if (modulesToTest.length) {
-        modulesToTest.forEach(function (moduleName) {
+        modulesToTest.forEach(function(moduleName) {
             modulesToTestSourceList = modulesToTestSourceList.concat(glob.sync('src/' + moduleName + '/test/*Spec.js'));
         });
     } else {
@@ -60,8 +57,8 @@ gulp.task('test', testRequirements, function (done) {
 
     var numberOfChunks = splittedModules.length;
 
-    console.log("\nITEMS IN CHUNK: " + itemInChunk);
-    console.log("NUMBER OF CHUNKS: " + numberOfChunks);
+    console.log('\nITEMS IN CHUNK: ' + itemInChunk);
+    console.log('NUMBER OF CHUNKS: ' + numberOfChunks);
 
     // Flag of existing errors.
     var totalErr = false;
@@ -93,7 +90,7 @@ gulp.task('test', testRequirements, function (done) {
             },
             singleRun: true
             // Function localDone will be executed in the last iteration.
-        }, currentChunk == numberOfChunks ? localDone : startServer).start();
+        }, currentChunk === numberOfChunks ? localDone : startServer).start();
     }
     startServer();
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,31 +1,31 @@
 var gulp = require('gulp');
 var runSequence = require('run-sequence');
 
-gulp.task('watch', function () {
+gulp.task('watch', function() {
     gulp.watch('src/doc/**/*.*', ['doc']);
 
-    gulp.watch('assets/**/*', function () {
+    gulp.watch('assets/**/*', function() {
         runSequence('copyAssets', 'server');
     });
 
     gulp.watch([
         'src/**/*.js',
         'vendors/leaflet/src/**/*.*'
-    ], function () {
+    ], function() {
         runSequence('buildScripts', 'server');
     });
 
-    gulp.watch('src/**/*.less', function () {
+    gulp.watch('src/**/*.less', function() {
         runSequence('rebuildStyles', 'server');
     });
 
-    gulp.watch('config.main.json', function () {
+    gulp.watch('config.main.json', function() {
         runSequence('build', 'server');
     });
 
     gulp.watch(['app/index.js', 'config.local.json'], ['server']);
 
-    gulp.watch('app/loader.js', function () {
+    gulp.watch('app/loader.js', function() {
         runSequence('loader', 'server');
     });
 

--- a/gulp/util/buildCSS.js
+++ b/gulp/util/buildCSS.js
@@ -17,7 +17,7 @@ var deps = require('../deps')(config);
 var stat = require('../util/stat');
 var error = require('./error');
 
-module.exports = function (options) {
+module.exports = function(options) {
     var imagesBasePath = path.resolve(__dirname + '/../../dist/img');
     var baseURL = config.appConfig.protocol + config.appConfig.baseUrl;
     var lessList = deps.getCSSFiles(options);
@@ -43,7 +43,7 @@ module.exports = function (options) {
         ];
     }
 
-    lessHeaderImports = lessHeaderImports.filter(function (src) {
+    lessHeaderImports = lessHeaderImports.filter(function(src) {
         var lessFileSrc = src.split(':')[0];
 
         try {

--- a/gulp/util/buildEnd.js
+++ b/gulp/util/buildEnd.js
@@ -4,10 +4,10 @@ var stat = require('./stat');
 var config = require('../../app/config');
 var deps = require('../deps')(config);
 
-module.exports = function () {
+module.exports = function() {
     console.log('Build contains the next modules:');
 
-    deps.getModulesList(util.env.pkg).forEach(function (module) {
+    deps.getModulesList(util.env.pkg).forEach(function(module) {
         console.log('- ' + module);
     });
 
@@ -21,7 +21,7 @@ module.exports = function () {
 
     var statValues = stat.get();
 
-    Object.keys(statValues).forEach(function (file, val) {
+    Object.keys(statValues).forEach(function(file) {
         console.log('- ' + file + ': ' + statValues[file]);
     });
 

--- a/gulp/util/destCSS.js
+++ b/gulp/util/destCSS.js
@@ -5,7 +5,7 @@ var gulp = require('gulp');
 var config = require('../../app/config');
 var buildCSS = require('../util/buildCSS');
 
-module.exports = function () {
+module.exports = function() {
     var buildRules = [];
 
     var skins = config.skins;
@@ -14,7 +14,7 @@ module.exports = function () {
 
     if (util.env.pkg || util.env.skin) {
         // Custom build
-        buildRules = browsers.map(function (browser) {
+        buildRules = browsers.map(function(browser) {
             return {
                 suffix: browser === 'ie8' ? 'ie8' : null,
                 pkg: util.env.pkg || 'full',
@@ -24,9 +24,9 @@ module.exports = function () {
             };
         });
     } else {
-        packages.forEach(function (pkg) {
-            skins.forEach(function (skin) {
-                browsers.forEach(function (browser) {
+        packages.forEach(function(pkg) {
+            skins.forEach(function(skin) {
+                browsers.forEach(function(browser) {
                     buildRules.push({
                         suffix: [pkg, skin, browser].join('.').replace(/\.$/, ''),
                         pkg: pkg,
@@ -39,9 +39,9 @@ module.exports = function () {
         });
     }
 
-    return buildRules.map(function (buildRule) {
+    return buildRules.map(function(buildRule) {
         return buildCSS(buildRule).pipe(gulp.dest('dist/css/'));
-    }).reduce(function (prev, next) {
+    }).reduce(function(prev, next) {
         return es.merge(prev, next);
     });
 };

--- a/gulp/util/error.js
+++ b/gulp/util/error.js
@@ -9,7 +9,7 @@ function errorNotify(err) {
     notify.onError({
         title: 'Build Error',
         message: '<%= error.message %>'
-    }, function () {
+    }, function() {
         console.error(util.colors.red('Build failure'));
 
         if (err.stack) {

--- a/gulp/util/gendoc.js
+++ b/gulp/util/gendoc.js
@@ -22,7 +22,7 @@ function walkItem(menu, callback) { // (Object, Function)
 function getMdFileNames() { // (Object) -> Object
     var menu = require('../../src/menu.json'),
         result = [];
-    walkItem(menu, function (filepath) {
+    walkItem(menu, function(filepath) {
         result.push(filepath);
     });
     return result;
@@ -49,13 +49,13 @@ function getMdFilesData(list, subdir) { // (Array, String) -> Array
 function copyConfigFile(filepath, destpath) { // (String, String)
     var configName = filepath.match(/[^/]+$/)[0];
 
-    mkdirp(destpath, function () {
+    mkdirp(destpath, function() {
         fs.writeFileSync(destpath + '/' + configName, fs.readFileSync(filepath));
     });
 }
 
 function writeFile(dir, htmlFileName, html) {
-    mkdirp(dir, function () {
+    mkdirp(dir, function() {
         fs.writeFileSync(dir + '/' + htmlFileName, html);
     });
 }
@@ -66,7 +66,7 @@ function generateDocumentation(config, rootPath, destPath) { // (Object, String,
         mdData = getMdFilesData(mdFileNames, rootPath);
 
     for (var i = 0, leng = mdData.length; i < leng; i++) {
-        (function (i) {
+        (function(i) {
             var mdFilePath = mdData[i].path,
                 htmlFileName = mdFilePath.match(/([\w_-]+)\.md$/i)[1] + '.html',
                 pluginDirName = mdFilePath.match(/\/?(.*)\/[.\w_-]+$/)[1],
@@ -76,11 +76,11 @@ function generateDocumentation(config, rootPath, destPath) { // (Object, String,
                 dir = destPath + '/' + pluginDirName + '/',
                 html;
 
-            renderer.listitem = function (text) {
+            renderer.listitem = function(text) {
                 return '<li><div class="restore-color">' + text + '</div></li>';
             };
 
-            renderer.heading = function (text, level) {
+            renderer.heading = function(text, level) {
                 if (typeof headerRepeats[text] === 'undefined') {
                     headerRepeats[text] = 0;
                 } else {
@@ -112,12 +112,12 @@ function generateTableOfContents(tokens) { // (Array) -> String
         headerRepeats = {};
 
     // extract headers from all tokens
-    tokens.forEach(function (token) {
-        if (token.type = 'heading' && token.depth > startH) headers.push(token);
+    tokens.forEach(function(token) {
+        if (token.type === 'heading' && token.depth > startH) headers.push(token);
     });
 
     // assign number for each header
-    headers.forEach(function (header) {
+    headers.forEach(function(header) {
         if (typeof headerRepeats[header.text] === 'undefined') {
             headerRepeats[header.text] = 0;
         }

--- a/gulp/util/projectList.js
+++ b/gulp/util/projectList.js
@@ -1,10 +1,10 @@
 var projectList;
 
 module.exports = {
-    set: function (val) {
+    set: function(val) {
         projectList = val;
     },
-    get: function () {
+    get: function() {
         return projectList;
     }
 };

--- a/gulp/util/templateStream.js
+++ b/gulp/util/templateStream.js
@@ -5,18 +5,18 @@ var dust = require('gulp-dust');
 var config = require('../../app/config.js');
 var deps = require('../deps')(config);
 
-module.exports = function (pkg) {
+module.exports = function(pkg) {
     var templateList = deps.getModulesList(pkg)
         .map(function(moduleName) {
             return 'src/' + moduleName + '/templates/*.dust';
         });
 
     return gulp.src(templateList).pipe(dust({
-        name: function (file) {
+        name: function(file) {
             var moduleName = path.basename(path.dirname(path.dirname(file.path)));
             var templateName = path.basename(file.relative, '.dust');
 
             return moduleName + '/' + templateName;
         }
     }));
-}
+};

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -2,13 +2,7 @@
 
 echo "Pre-push hooks started"
 
-if ! npm run lint
-then
-    echo "Linting is failed"
-    exit 1
-fi
-
-if ! npm run test
+if ! npm test
 then
     echo "Test is failed"
     exit 1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "node app",
-    "test": "gulp test",
+    "test": "gulp lint && gulp test",
     "lint": "gulp lint",
     "dev": "gulp dev",
     "pub": "gulp clean && gulp build --npm && npm publish"

--- a/test/after.js
+++ b/test/after.js
@@ -5,8 +5,8 @@ DG.Map.mergeOptions({
 
 // Add function for remove all layers on map. Need for tests of leaflet, because we have our layers.
 DG.Map.include({
-    'clearLayers': function () {
-        this.eachLayer(function (layer) {
+    'clearLayers': function() {
+        this.eachLayer(function(layer) {
             this.removeLayer(layer);
         }, this);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var argv = require('optimist').argv;
 
-exports.getBrowsers = function () {
+exports.getBrowsers = function() {
     var browsers = ['PhantomJS'];
 
     if (argv.hasOwnProperty('ff')) {
@@ -22,7 +22,7 @@ exports.getBrowsers = function () {
     return browsers;
 };
 
-exports.getReporters = function (isDebug) {
+exports.getReporters = function(isDebug) {
     var reporters = isDebug ? ['mocha'] : ['dots'];
 
     reporters.push('coverage');
@@ -34,11 +34,11 @@ exports.getReporters = function (isDebug) {
     return reporters;
 };
 
-exports.getJunitReporter = function () {
+exports.getJunitReporter = function() {
     var junitReporter = {};
 
     if (argv.hasOwnProperty('junitOutput')) {
-        junitReporter["outputFile"] = argv.junitOutput;
+        junitReporter['outputFile'] = argv.junitOutput;
     }
 
     return junitReporter;


### PR DESCRIPTION
Некоторые изменения по стилю кода и линтеру:

1. теперь линтинг js и css будет запускаться в CI - странно, что этого не было
2. в таску `lintJS` добавил `failAfterError` - если линтер ругается, то выйдет с кодом 1 (а раньше с 0 выходил и не прерывал последующие скрипты)
3. убрал неиспользуемые глобальные объекты из линтера: `dust`, `module`, `define`
4. по возможности пофиксил кодстайл в остальных местах