### PR TITLE
Suppress Enter key click in Geoclicker

### DIFF
--- a/src/DGGeoclicker/src/DGGeoclicker.js
+++ b/src/DGGeoclicker/src/DGGeoclicker.js
@@ -76,6 +76,9 @@ DG.Geoclicker = DG.Handler.extend({
         },
 
         click: function(e) { // (Object)
+            if (!e.latlng) {
+                return; // suppress Enter key click
+            }
             if (this.clickCount === 0) {
                 this.clickCount = 1;
                 this._singleClick(e);


### PR DESCRIPTION
Если кликнуть в карту, затем нажать Enter, то он произведёт клик, который посыплет ошибку в консоль. Здесь же клавиатура в геокликере игнорится.