### PR TITLE
Suppress Enter key click in Ruler

### DIFF
--- a/src/DGRulerControl/src/Control.Ruler.js
+++ b/src/DGRulerControl/src/Control.Ruler.js
@@ -62,6 +62,9 @@ DG.Control.Ruler = DG.RoundControl.extend({
     },
 
     _handleMapClick: function(event) { // (MouseEvents)
+        if (!event.latlng) {
+            return; // supress Enter key click
+        }
         this._drawingHelper.addLatLng(event.latlng);
     },
 


### PR DESCRIPTION
Подавляет обработку нажатия клавиши Enter при создании точек рулеткой.
Аналогично https://github.com/2gis/mapsapi/pull/424