### PR TITLE
Request tiles on move

### DIFF
--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -23,7 +23,8 @@ DG.Map.addInitHook(function() {
         detectRetina: DG.config.detectRetina,
         maxZoom: 19,
         maxNativeZoom: 19,
-        zIndex: 0
+        zIndex: 0,
+        updateWhenIdle: false // it's okay with preview tiles
     }).addTo(this);
 
     function updateErrorTileUrl() {

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -405,6 +405,7 @@ L.MobileTileLayer = L.TileLayer.extend({
 
         tile.loaded = +new Date();
         tile.active = true;
+        this._pruneTiles();
 
         if (!err) {
             tile.el.style.visibility = '';


### PR DESCRIPTION
Теперь тайлы будут грузиться по событию `move`, а не `moveend` на мобильных девайсах. Интересно, что основные тайлы не забивают полностью канал, и сжатые тайлы все равно продолжают грузиться.