### PR TITLE
Request retina preview tiles

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -34,6 +34,7 @@
     "tileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
     "retinaTileServer": "//rtile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
     "previewTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64",
+    "previewRetinaTileServer": "//rtile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64",
 
     "trafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
     "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -146,7 +146,9 @@ if (DG.Browser.mobile) {
 L.MobileTileLayer = L.TileLayer.extend({
     initialize: function(url, options) {
         L.TileLayer.prototype.initialize.call(this, url, options);
-        this._previewUrl = DG.config.previewTileServer;
+
+        this._previewUrl = DG.config.protocol +
+            (DG.Browser.retina ? DG.config.previewRetinaTileServer : DG.config.previewTileServer);
     },
 
     /**


### PR DESCRIPTION
Теперь в случае ретина мобильного дисплея будет запрашиваться превью тайлы с домена ретина тайлов. И наоборот, в случае обычного дисплея – с домена обычных тайлов.