### PR TITLE
append leaflet build id to file

### DIFF
--- a/gulp/tasks/buildLeaflet.js
+++ b/gulp/tasks/buildLeaflet.js
@@ -46,7 +46,7 @@ function getLeafletFiles(compsBase32) {
     return files;
 }
 
-// leafletCustomBuild parameter for set id of leaflet build. See more in leaflet/build/build.html
+// leaflet-custom-build parameter for set id of leaflet build. See more in leaflet/build/build.html
 gulp.task('buildLeaflet', function () {
     var leafletCustomBuild = util.env['leaflet-custom-build'];
     return (leafletCustomBuild ? gulp.src(getLeafletFiles(leafletCustomBuild).map(function (file) {

--- a/gulp/tasks/buildScripts.js
+++ b/gulp/tasks/buildScripts.js
@@ -12,6 +12,7 @@ var util = require('gulp-util');
 var gulp = require('gulp');
 var path = require('path');
 var map = require('map-stream');
+var insert = require('gulp-insert');
 
 gulp.task('buildScripts', ['concatScripts'], function() {
     var isCustom = util.env.pkg || util.env.skin;
@@ -48,6 +49,11 @@ gulp.task('buildScripts', ['concatScripts'], function() {
             .pipe(derequire())
             .pipe(gulpif(util.env.release, uglify()))
             .pipe(gulpif(util.env.release, header(config.copyright)))
+            .pipe(gulpif(
+                Boolean(util.env['leaflet-custom-build']),
+                insert.prepend('// leaflet-custom-build: ' + util.env['leaflet-custom-build'] + '\n')
+                )
+            )
             .pipe(map(stat.save))
             .pipe(gulp.dest('dist/js/'));
     }).reduce(function(prev, curr) {

--- a/gulp/tasks/buildScripts.js
+++ b/gulp/tasks/buildScripts.js
@@ -52,8 +52,7 @@ gulp.task('buildScripts', ['concatScripts'], function() {
             .pipe(gulpif(
                 Boolean(util.env['leaflet-custom-build']),
                 insert.prepend('// leaflet-custom-build: ' + util.env['leaflet-custom-build'] + '\n')
-                )
-            )
+            ))
             .pipe(map(stat.save))
             .pipe(gulp.dest('dist/js/'));
     }).reduce(function(prev, curr) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-header": "1.8.2",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.4.0",
+    "gulp-insert": "^0.5.0",
     "gulp-less": "^3.0.5",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",


### PR DESCRIPTION
Если используется кастомная сборка лифлета, то в начале файла запишется id, что бы его не забыть потом, а то сейчас постоянно забывается