### PR TITLE
add retina traffic urls

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -37,9 +37,9 @@
     "previewRetinaTileServer": "//rtile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64",
 
     "trafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
-    "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
+    "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/retina/{timestampString}",
     "trafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/{timestampString}",
-    "retinaTrafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/{timestampString}",
+    "retinaTrafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/retina/{timestampString}",
     "trafficTimestampServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/speed/time/",
     "trafficScoreServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/score/0/",
 


### PR DESCRIPTION
Теперь есть ретина-тайлы для трафика.

Пруф:

https://traffic0.maps.2gis.com/novosibirsk/traffic/11/1495/647/speed/0/?1506928188535
https://traffic0.maps.2gis.com/novosibirsk/traffic/11/1495/647/speed/0/retina/?1506928188535

https://meta1.maps.2gis.com/novosibirsk/meta/11/1495/646/graph_speed/0/?1506928188535
https://meta1.maps.2gis.com/novosibirsk/meta/11/1495/646/graph_speed/0/retina/?1506928188535
