### PR TITLE
Use different methods for popup close by map click and by close button

### DIFF
--- a/src/DGPopup/src/DGPopup.js
+++ b/src/DGPopup/src/DGPopup.js
@@ -174,6 +174,13 @@ require('../../../vendors/baron');
             return (o.nodeName ? true : false);
         },
 
+        _onCloseButtonClick: function(e) {
+            if (this._map) {
+                this._map.closePopup(this);
+            }
+            L.DomEvent.stop(e);
+        },
+
         _close: function() {
             if (this._map) {
                 if (DG.Browser.mobile && this._map.geoclicker &&


### PR DESCRIPTION
Правит следующий баг в мобилке:
> Открываем http://maps.api.2gis.ru/2.0/
> 1. Закрываем колаут
> 2. Кликаем в карту
> ОР: Открылся колаут
> ФР: Ничего не произошло
> 3. Кликаем в ту же точку
> ФР: Появился колаут

Разделил поведение закрытия попапа при клике в карту и при клике на закрывающую кнопку.