### PR TITLE
Fix retina traffic logic

### DIFF
--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -18,7 +18,7 @@ DG.Traffic = DG.TileLayer.extend({
             errorTileUrl: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
             subdomains: '012345679',
             maxNativeZoom: 18,
-            detectRetina: true,
+            detectRetina: DG.config.detectRetina,
             minZoom: DG.config.trafficLayerMinZoom
         };
 


### PR DESCRIPTION
Фиксит баг:
> Включаем пробки на ретина экране
Зумимся ввер/вниз
ОР: Для пробок подгружаются тайлы с текущим зумом
ФР: Для пробок подгружаются тайлы с текущим зумом + 1
Из-за этого тайлы могут выглядеть криво и некрасиво, мести видно эффект лесенки
У запросов к meta тоже зум больше чем нужно