### PR TITLE
Mousemove refactoring

### DIFF
--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -42,3 +42,20 @@ DG.setOptions = L.setOptions = DG.Util.setOptions = function(obj, options) {
 DG.Layer.mergeOptions({
     nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu']
 });
+
+DG.DomEvent.getEventPath = function(event) {
+    if (event.path) {
+        return event.path; // chrome
+    }
+    var path = [];
+    var currentElem = event.target || event.srcElement;
+    while (currentElem) {
+        path.push(currentElem);
+        currentElem = currentElem.parentElement;
+    }
+    if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
+        path.push(document);
+    if (path.indexOf(window) === -1)
+        path.push(window);
+    return path;
+};

--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -61,6 +61,7 @@ DG.DomEvent.getEventPath = function(event) {
 };
 
 L.Canvas.include({
+    // overwrite the function without mousemove debounce as it breaks metalayers events
     _initContainer: function() {
         var container = this._container = document.createElement('canvas');
 

--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -51,7 +51,7 @@ DG.DomEvent.getEventPath = function(event) {
     var currentElem = event.target || event.srcElement;
     while (currentElem) {
         path.push(currentElem);
-        currentElem = currentElem.parentElement;
+        currentElem = currentElem.parentElement || currentElem.parentNode;
     }
     if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
         path.push(document);

--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -59,3 +59,16 @@ DG.DomEvent.getEventPath = function(event) {
         path.push(window);
     return path;
 };
+
+L.Canvas.include({
+    _initContainer: function() {
+        var container = this._container = document.createElement('canvas');
+
+        L.DomEvent
+            .on(container, 'mousemove', this._onMouseMove, this)
+            .on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this)
+            .on(container, 'mouseout', this._handleMouseOut, this);
+
+        this._ctx = container.getContext('2d');
+    }
+});

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -252,7 +252,6 @@ DG.Map.include({
                 targets[i].fire(type, data, true);
                 if (this._lastMetalayer.entity && data.originalEvent._stopped) {
                     // fixes L.circle([54.983136831455, 82.897440725094], 200).addTo(map);
-                    // but blinks L.circle( [54.980156831455, 82.897440725094], 200, { renderer: L.canvas() } ).addTo(map);
                     this._fireMetalayerEvent('mouseout', this._lastMetalayer, data);
                     this._lastMetalayer = {
                         layer: undefined,

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -235,7 +235,6 @@ DG.Map.include({
                         this._lastMetalayer.entity.id === metalayer.entity.id) {
                         this._fireMetalayerEvent('mousemove', metalayer, data);
                     } else {
-                        // todo check removing debounce in events
                         this._fireMetalayerEvent('mouseout', this._lastMetalayer, data);
                         this._fireMetalayerEvent('mouseover', metalayer, data);
                         this._fireMetalayerEvent('mousemove', metalayer, data);
@@ -250,14 +249,16 @@ DG.Map.include({
                     targets[i].fire(type, data, true);
                 }
             } else {
-                // fixes L.circle([54.983136831455, 82.897440725094], 200).addTo(map);
-                // but blinks L.circle( [54.980156831455, 82.897440725094], 200, { renderer: L.canvas() } ).addTo(map);
-                this._fireMetalayerEvent('mouseout', this._lastMetalayer, data);
-                this._lastMetalayer = {
-                    layer: undefined,
-                    entity: undefined
-                };
                 targets[i].fire(type, data, true);
+                if (this._lastMetalayer.entity && data.originalEvent._stopped) {
+                    // fixes L.circle([54.983136831455, 82.897440725094], 200).addTo(map);
+                    // but blinks L.circle( [54.980156831455, 82.897440725094], 200, { renderer: L.canvas() } ).addTo(map);
+                    this._fireMetalayerEvent('mouseout', this._lastMetalayer, data);
+                    this._lastMetalayer = {
+                        layer: undefined,
+                        entity: undefined
+                    };
+                }
             }
 
             if (data.originalEvent._stopped ||


### PR DESCRIPTION
События больше не прокидываются на несколько объектов, которые под мышкой - только верхний идентифицируется.

Теперь корректно работают переходы мышки в метаслоях между собой и между обычными html элементами - для предыдущего объекта бросается `mouseout`, для нового `mouseover`.

Вот таких проблем больше нет:

![label_under_marker](https://user-images.githubusercontent.com/2605831/34195856-2b7029b6-e592-11e7-9fab-1f50846b072f.png)
![label-under-popup](https://user-images.githubusercontent.com/2605831/34195859-2b953f4e-e592-11e7-9f1e-1f4b768124db.png)
![two-labels](https://user-images.githubusercontent.com/2605831/34195860-2bb80b00-e592-11e7-9afe-7878c56dd3ca.png)
