### PR TITLE
Support tile set parameter in tile urls

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -31,10 +31,10 @@
 
     "baseUrl": "//maps.api.2gis.ru/2.0",
 
-    "tileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
-    "retinaTileServer": "//rtile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1",
-    "previewTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64",
-    "previewRetinaTileServer": "//rtile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64",
+    "tileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&ts=online_sd",
+    "retinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&ts=online_hd",
+    "previewTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_sd",
+    "previewRetinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_hd",
 
     "trafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
     "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/retina/{timestampString}",
@@ -43,8 +43,8 @@
     "trafficTimestampServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/speed/time/",
     "trafficScoreServer": "//traffic{s}.maps.2gis.com/{projectCode}/meta/score/0/",
 
-    "poiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1",
-    "retinaPoiMetaServer": "//rtile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1",
+    "poiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_sd",
+    "retinaPoiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_hd",
 
     "webApiServer": "//catalog.api.2gis.ru",
 

--- a/config.main.json
+++ b/config.main.json
@@ -36,6 +36,11 @@
     "previewTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_sd",
     "previewRetinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_hd",
 
+    "arabicTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&ts=online_sd_ar",
+    "arabicRetinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&ts=online_hd_ar",
+    "arabicPreviewTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_sd_ar",
+    "arabicPreviewRetinaTileServer": "//tile{s}.maps.2gis.com/tiles?x={x}&y={y}&z={z}&v=1&size=64&ts=online_hd_ar",
+
     "trafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/{timestampString}",
     "retinaTrafficTileServer": "//traffic{s}.maps.2gis.com/{projectCode}/traffic/{z}/{x}/{y}/speed/{period}/retina/{timestampString}",
     "trafficMetaServer": "//meta{s}.maps.2gis.com/{projectCode}/meta/{z}/{x}/{y}/graph_speed/{period}/{timestampString}",
@@ -45,6 +50,9 @@
 
     "poiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_sd",
     "retinaPoiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_hd",
+
+    "arabicPoiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_sd_ar",
+    "arabicRetinaPoiMetaServer": "//tile{s}.maps.2gis.com/poi?x={x}&y={y}&z={z}&v=1&ts=online_hd_ar",
 
     "webApiServer": "//catalog.api.2gis.ru",
 

--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -16,6 +16,13 @@ DG.Map.addInitHook(function() {
     });
 
     var tileUrl = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer);
+    var arabicTileUrl = DG.config.protocol +
+        (DG.Browser.retina ? DG.config.arabicRetinaTileServer : DG.config.arabicTileServer);
+
+    var previewTileUrl = DG.config.protocol +
+        (DG.Browser.retina ? DG.config.previewRetinaTileServer : DG.config.previewTileServer);
+    var arabicPreviewTileUrl = DG.config.protocol +
+        (DG.Browser.retina ? DG.config.arabicPreviewRetinaTileServer : DG.config.arabicPreviewTileServer);
 
     this.baseLayer = new BaseLayer(tileUrl, {
         subdomains: '0123',
@@ -24,7 +31,8 @@ DG.Map.addInitHook(function() {
         maxZoom: 19,
         maxNativeZoom: 19,
         zIndex: 0,
-        updateWhenIdle: false // it's okay with preview tiles
+        updateWhenIdle: false, // it's okay with preview tiles
+        previewUrl: previewTileUrl,
     });
 
     var currentTilesLang = ''; // 'ar' | ''
@@ -42,11 +50,17 @@ DG.Map.addInitHook(function() {
         // Change 2GIS tiles for Arabic language in Dubai project
         if (currentTilesLang === '' && lang === 'ar' && project && project.country_code === 'ae') {
             currentTilesLang = 'ar';
-            this.baseLayer.setUrl(tileUrl + '_ar');
+            this.baseLayer.setUrl(arabicTileUrl);
+            if (this.baseLayer.setPreviewUrl) {
+                this.baseLayer.setPreviewUrl(arabicPreviewTileUrl);
+            }
 
         } else if (currentTilesLang === 'ar' && (lang !== 'ar' || (!project || project.country_code !== 'ae'))) {
             currentTilesLang = '';
             this.baseLayer.setUrl(tileUrl);
+            if (this.baseLayer.setPreviewUrl) {
+                this.baseLayer.setPreviewUrl(previewTileUrl);
+            }
         }
     }
 

--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -42,8 +42,7 @@ DG.Map.addInitHook(function() {
         // Change 2GIS tiles for Arabic language in Dubai project
         if (currentTilesLang === '' && lang === 'ar' && project && project.country_code === 'ae') {
             currentTilesLang = 'ar';
-            var arabicParameter = DG.Browser.retina ? '&ts=webapi_tileset_ar.hd' : '&ts=webapi_tileset_ar';
-            this.baseLayer.setUrl(tileUrl + arabicParameter);
+            this.baseLayer.setUrl(tileUrl + '_ar');
 
         } else if (currentTilesLang === 'ar' && (lang !== 'ar' || (!project || project.country_code !== 'ae'))) {
             currentTilesLang = '';

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -7,7 +7,7 @@ if (DG.Browser.mobile) {
         /**
          * Хакаем addClass и removeClass, чтобы они не работали для определённых классов
          * Сделано так, чтобы не менять кучу методов в кишках лифлета
-         * 
+         *
          * leaflet-dragging и leaflet-drag-target вызывает длинный recalculate style
          */
         var addClass = L.DomUtil.addClass;
@@ -147,8 +147,12 @@ L.MobileTileLayer = L.TileLayer.extend({
     initialize: function(url, options) {
         L.TileLayer.prototype.initialize.call(this, url, options);
 
-        this._previewUrl = DG.config.protocol +
-            (DG.Browser.retina ? DG.config.previewRetinaTileServer : DG.config.previewTileServer);
+        this._previewUrl = options.previewUrl;
+    },
+
+    setPreviewUrl: function(url) {
+        this._previewUrl = url;
+        this.redraw();
     },
 
     /**

--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -54,13 +54,15 @@ DG.Poi = DG.Handler.extend({
 
     _updateUrl: function() {
         var url = DG.config.protocol + (DG.Browser.retina ? DG.config.retinaPoiMetaServer : DG.config.poiMetaServer);
+        var arabicUrl = DG.config.protocol +
+            (DG.Browser.retina ? DG.config.arabicRetinaPoiMetaServer : DG.config.arabicPoiMetaServer);
         var lang = this._map.getLang();
         var project = this._map.projectDetector && this._map.projectDetector.getProject();
 
         // Change POI for Arabic language in Dubai project
         if (this._currentTilesLang === '' && lang === 'ar' && project && project.country_code === 'ae') {
             this._currentTilesLang = 'ar';
-            this._metaLayer.setUrl(url + '_ar');
+            this._metaLayer.setUrl(arabicUrl);
 
         } else if (this._currentTilesLang === 'ar' && (lang !== 'ar' || (!project || project.country_code !== 'ae'))) {
             this._currentTilesLang = '';

--- a/src/DGPoi/src/DGPoi.js
+++ b/src/DGPoi/src/DGPoi.js
@@ -60,8 +60,7 @@ DG.Poi = DG.Handler.extend({
         // Change POI for Arabic language in Dubai project
         if (this._currentTilesLang === '' && lang === 'ar' && project && project.country_code === 'ae') {
             this._currentTilesLang = 'ar';
-            var arabicParameter = DG.Browser.retina ? '&ts=webapi_tileset_ar.hd' : '&ts=webapi_tileset_ar';
-            this._metaLayer.setUrl(url + arabicParameter);
+            this._metaLayer.setUrl(url + '_ar');
 
         } else if (this._currentTilesLang === 'ar' && (lang !== 'ar' || (!project || project.country_code !== 'ae'))) {
             this._currentTilesLang = '';


### PR DESCRIPTION
Все запросы за тайлами теперь должны содержать параметр `ts`, указывающий на нужный тайлсет.

Для обычных тайлов этот параметр равен `online_sd`.
Для ретина тайлов — `online_hd`.

Для тайлов на арабском языке к параметру добавляется `_ar`, т.е. `online_sd_ar` или `online_hd_ar`.