### PR TITLE
Use event from arguments instead window.event in label mouseout handler

### DIFF
--- a/src/DGLabel/src/Path.DGLabel.js
+++ b/src/DGLabel/src/Path.DGLabel.js
@@ -36,7 +36,7 @@ DG.Path.include({
             this._label.setPosition(event.latlng);
             DG.DomEvent.stop(event);
         },
-        mouseout: function() {
+        mouseout: function(event) {
             this._map.removeLayer(this._label);
             DG.DomEvent.stop(event);
         },


### PR DESCRIPTION
Если в firefox добавить `Polyline` на карту и навесить на него `Label`:
```js
DG.polyline([[54.98550, 82.89684], [54.98445, 82.90572], [54.98874, 82.90298]])
  .addTo(map)
  .bindLabel('test');
```
Затем навести, а потом увести мышку с полилинии, то выскочит эксепшен:
![2018-02-02 11 20 39](https://user-images.githubusercontent.com/3996552/35716375-267c752c-080b-11e8-842f-105507efb947.png)

Пофиксал, добавив использование `event` из аргументов, а не глобального `window.event`.