### PR TITLE
Fix iphone pinch bug

### DIFF
--- a/src/DGCustomization/skin/basic/less/dg-customization.less
+++ b/src/DGCustomization/skin/basic/less/dg-customization.less
@@ -82,8 +82,3 @@
     touch-action: auto;
     -ms-touch-action: auto;
 }
-
-.leaflet-image-layer,
-.leaflet-tile-container {
-    pointer-events: auto;
-}

--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -43,23 +43,6 @@ DG.Layer.mergeOptions({
     nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu']
 });
 
-DG.DomEvent.getEventPath = function(event) {
-    if (event.path) {
-        return event.path; // chrome
-    }
-    var path = [];
-    var currentElem = event.target || event.srcElement;
-    while (currentElem) {
-        path.push(currentElem);
-        currentElem = currentElem.parentElement || currentElem.parentNode;
-    }
-    if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
-        path.push(document);
-    if (path.indexOf(window) === -1)
-        path.push(window);
-    return path;
-};
-
 L.Canvas.include({
     // overwrite the function without mousemove debounce as it breaks metalayers events
     _initContainer: function() {

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -273,7 +273,7 @@ DG.Map.include({
         if (
             // For all browsers which support pointer-events: none on tiles
             eventTarget === this._container ||
-            // And for IE10 or less targets will tiles
+            // And for IE10 or less where targets are tiles
             DG.Browser.ie && eventTarget.className === 'leaflet-tile leaflet-tile-loaded' ||
             // The only exception is canvas, because a canvas layer occupies the whole screen
             eventTarget.tagName === 'CANVAS'

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -266,13 +266,21 @@ DG.Map.include({
     },
 
     _getCurrentMetaLayer: function(data) {
-        for (var j = this.metaLayers.length - 1; j >= 0; j--) {
-            var metaEntity = this.metaLayers[j].getHoveredObject(data);
-            if (metaEntity) {
-                return {
-                    layer: this.metaLayers[j],
-                    entity: metaEntity
-                };
+        /**
+         * Suppose that user can interact with the metalayer only if there are no layers between cursor and map
+         * The only exception is canvas, because a canvas layer occupies the whole screen
+         */
+        if (data.originalEvent.target === this._container ||
+            data.originalEvent.target.tagName === 'CANVAS'
+        ) {
+            for (var j = this.metaLayers.length - 1; j >= 0; j--) {
+                var metaEntity = this.metaLayers[j].getHoveredObject(data);
+                if (metaEntity) {
+                    return {
+                        layer: this.metaLayers[j],
+                        entity: metaEntity
+                    };
+                }
             }
         }
         return {

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -266,12 +266,17 @@ DG.Map.include({
     },
 
     _getCurrentMetaLayer: function(data) {
-        /**
-         * Suppose that user can interact with the metalayer only if there are no layers between cursor and map
-         * The only exception is canvas, because a canvas layer occupies the whole screen
-         */
-        if (data.originalEvent.target === this._container ||
-            data.originalEvent.target.tagName === 'CANVAS'
+        // Not forget for IE8 with srcElement
+        var eventTarget = data.originalEvent.target || data.originalEvent.srcElement;
+
+        // Suppose that user can interact with the metalayer only if there are no layers between cursor and map
+        if (
+            // For all browsers which support pointer-events: none on tiles
+            eventTarget === this._container ||
+            // And for IE10 or less targets will tiles
+            DG.Browser.ie && eventTarget.className === 'leaflet-tile leaflet-tile-loaded' ||
+            // The only exception is canvas, because a canvas layer occupies the whole screen
+            eventTarget.tagName === 'CANVAS'
         ) {
             for (var j = this.metaLayers.length - 1; j >= 0; j--) {
                 var metaEntity = this.metaLayers[j].getHoveredObject(data);

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -189,6 +189,7 @@ L.MobileTileLayer = L.TileLayer.extend({
         tile.style.height = tileSize.y + 'px';
 
         tile.style.visibility = 'hidden';
+        tile.style.pointerEvents = 'none';
 
         tile.onselectstart = L.Util.falseFn;
         tile.onmousemove = L.Util.falseFn;
@@ -369,7 +370,7 @@ L.MobileTileLayer = L.TileLayer.extend({
         var url = needPreview ? this._previewUrl : this._url;
         var tile = this.createTile(wrapCoords, L.bind(this._tileReady, this, coords), url);
 
-        this._initTile(tile, needPreview);
+        this._initTile(tile);
 
         L.DomUtil.setPosition(tile, tilePos);
 

--- a/src/DGMeta/src/DGMeta.Layer.js
+++ b/src/DGMeta/src/DGMeta.Layer.js
@@ -102,13 +102,6 @@ DG.Meta.Layer = DG.Layer.extend({
     },
 
     getHoveredObject: function(event) {
-        var path = DG.DomEvent.getEventPath(event.originalEvent);
-        if (path.indexOf(this._map._panes.tilePane) === -1 &&
-            path.indexOf(this._map._panes.overlayPane) === -1) {
-            // not metalayer object over
-            return;
-        }
-
         var tileSize = this.getTileSize(),
             layerPoint = this._map.mouseEventToLayerPoint(event.originalEvent),
             tileOriginPoint = this._map.getPixelOrigin().add(layerPoint),


### PR DESCRIPTION
Поправил баги на айфоне связанные с зумом, теперь всё должно работать хорошо.

Для этого пришлось снова немного переделать механику работы с эвентами POI, т.к. для фикса пришлось сделать все тайлы недоступные для эвентов мыши (в оригинальном Leaflet так и есть).

Принял два предположения:
1. Считаем, что взаимодействия с POI нет, если любой слой попадает между мышкой и картой
2. На канвас это ограничение не распространяется, его наличие для эвентов по POI мы игнорируем

Что желательно проверить:
- Механику работы зума на iphone и других мобилках, при этом посмотреть на пожатые тайлы
- Пересмотреть все кейсы связанные с событиями по POI, я вроде бы посмотрел все баги, что всплывали в https://github.com/2gis/mapsapi/pull/453, но вдруг что-то пропустил

Кажется, есть одно изменившееся поведение:
Если взять примеры с геометриями со страницы [документации](http://api.2gis.ru/doc/maps/ru/examples/vector-layers/#%D0%BE%D1%82%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5-%D0%BF%D1%80%D1%8F%D0%BC%D0%BE%D1%83%D0%B3%D0%BE%D0%BB%D1%8C%D0%BD%D0%B8%D0%BA%D0%BE%D0%B2), то они не будут пропускать события, и POI не будут ховериться под ними.
Считаю, что это **нормально**, т.к. все геометрии создаются по умолчанию интерактивными, т.е. с параметром `interactive: true`, если его поставить в `false`, то POI начнут ховериться под такими геометриями.