### PR TITLE
TILES-14750 fix GA set anonymizeIp

### DIFF
--- a/config.main.json
+++ b/config.main.json
@@ -26,6 +26,7 @@
     "flampUrl": "http://flamp.ru/r/",
     "flampGoogleAnalytics": "utm_source=api2gis&utm_medium=api&utm_campaign=geoclicker",
     "gaCode": "UA-38243181-2",
+    "gaName": "mapsapi2gis",
 
     "protocol": "http:",
 

--- a/src/DGCore/src/DGCore.js
+++ b/src/DGCore/src/DGCore.js
@@ -44,10 +44,10 @@ DG.Map.addInitHook((function() {
         /*eslint-disable */
         ga('create', DG.config.gaCode, {
             storage: 'none', // don't store and use cookies thanks GDPR
-            name: 'mapsapi2gis'
+            name: DG.config.gaName
         });
-        ga('set', 'anonymizeIp', true);
-        ga('mapsapi2gis.send', 'pageview');
+        ga(DG.config.gaName + '.set', 'anonymizeIp', true);
+        ga(DG.config.gaName + '.send', 'pageview');
         /*eslint-enable */
 
         var newImg = new Image();


### PR DESCRIPTION
https://jira.2gis.ru/browse/TILES-1475

В GA у вашего счетчика при pageview не передается параметр aip=1(он же anonymizeIp), а должен.
Проблема в том что у команды set не указано имя вашего счетчика

Все по рекомендациям оф. доки:
```
Выполнение команд для отдельного счетчика
Использование нескольких счетчиков
https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers
```