### PR TITLE
Use the package version instead of the github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dustjs-helpers": "1.7.3",
     "dustjs-linkedin": "2.7.5",
     "html5shiv": "^3.7.3",
-    "leaflet": "git://github.com/Leaflet/Leaflet.git#v1.0.1"
+    "leaflet": "1.0.1"
   },
   "devDependencies": {
     "ansi-colors": "^2.0.1",


### PR DESCRIPTION
Why use a github repository link?