### PR TITLE
Fix web page scrolling when scroll on popup

### DIFF
--- a/src/DGPopup/src/DGPopup.js
+++ b/src/DGPopup/src/DGPopup.js
@@ -198,6 +198,14 @@ require('../../../vendors/baron');
 
         _initLayout: function() {
             originalInitLayout.call(this);
+
+            // Prevents scroll events for div.leaflet-popup-content (this._contentNode) from web page scrolling when popup is opened
+            DG.DomEvent.on(this._contentNode,'mousewheel', function(e) {
+                if (e.path.indexOf(this._scroller) === -1) {
+                    e.preventDefault();
+                }
+            }, this);
+         
             this._innerContainer = DG.DomUtil.create('div', 'leaflet-popup-inner ' + this._popupHideClass, this._container);
 
             // Prevents mouse events from leaking through close button

--- a/src/DGPopup/src/DGPopup.js
+++ b/src/DGPopup/src/DGPopup.js
@@ -200,8 +200,21 @@ require('../../../vendors/baron');
             originalInitLayout.call(this);
 
             // Prevents scroll events for div.leaflet-popup-content (this._contentNode) from web page scrolling when popup is opened
-            DG.DomEvent.on(this._contentNode,'mousewheel', function(e) {
-                if (e.path.indexOf(this._scroller) === -1) {
+            DG.DomEvent.on(this._contentNode, 'wheel', function(e) {
+                var eventPath;
+
+                if (e.composedPath) {
+                    eventPath = e.composedPath();
+                } else {
+                    var elem = e.target;
+                    eventPath = [];
+                    while (elem.parentNode) {
+                        eventPath.push(elem);
+                        elem = elem.parentNode;
+                    }
+                }
+
+                if (eventPath.indexOf(this._scroller) === -1 || eventPath.indexOf(this._barWrapper) !== -1) {
                     e.preventDefault();
                 }
             }, this);


### PR DESCRIPTION
Изменения предотвращают скроллинг страницы в случае, когда курсор находится над попапом. Поскольку leaflet обертка (this._contentNode) инициируется один раз при работе с картой, то listener-функция с этого элемента не удалется. При возникновении события mousewheel на this._contentNode проверяется event.path: если в событии не участвует обертка скроллера (this._scroller), то предотвращать действие по умолчанию - скроллинг страницы.