### PR TITLE
display traffic layer on move for mobile

### DIFF
--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -1,7 +1,8 @@
 DG.Traffic = DG.TileLayer.extend({
     options: {
         period: 0,
-        disableLabel: false
+        disableLabel: false,
+        updateWhenIdle: false // display new traffic tiles on move for mobile
     },
 
     statics: {


### PR DESCRIPTION
В опциях класса DG.Traffic свойство updateWhenIdle установлено false. Ранее по умолчанию для мобильных браузеров это свойство выставлялось в true, в результате чего тайлы грузились по окончании понаромирования.