### PR TITLE
Check flags field for project data

### DIFF
--- a/src/DGProjectDetector/src/DGProjectDetector.js
+++ b/src/DGProjectDetector/src/DGProjectDetector.js
@@ -81,6 +81,7 @@ DG.ProjectDetector = DG.Handler.extend({
                 check(project.code) &&
                 check(project.domain) &&
                 check(project.country_code) &&
+                check(project.flags) &&
                 project.zoom_level &&
                     check(project.zoom_level.min) &&
                     check(project.zoom_level.max) &&


### PR DESCRIPTION
В валидацию данных проекта также добавил проверку на наличие поля `flags`.
Оно используется ниже:
https://github.com/2gis/mapsapi/blob/63a159a09d833893f823eb1f082ae7b1b72f69d0/src/DGProjectDetector/src/DGProjectDetector.js#L117-L119