### PR TITLE
fix click on poi when slow network connection

### DIFF
--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -213,6 +213,9 @@ DG.Map.include({
             L.DomEvent.preventDefault(e);
         }
 
+        // The eventTargets and eventTargetsMapIndex properties are used for fire events continuation to
+        // remaining targets when the event was stopped due to the tile meta data request in progress.
+        // In this case there is need to fire events to remaining targets asynchronously.
         var data = {
             originalEvent: e,
             eventTargets: targets,
@@ -289,6 +292,9 @@ DG.Map.include({
                         entity: metaEntity
                     };
                 } else if (isClick) {
+                    // Additional condition for click event, because there may not be the tile meta data.
+                    // E.g. when the tile meta data request in progress. In this case the metalayer must be
+                    // returned without an entity.
                     return {
                         layer: this.metaLayers[j],
                         entity: undefined
@@ -303,10 +309,13 @@ DG.Map.include({
     },
 
     _fireMetalayerEvent: function(type, metalayer, data) {
+        // There is need to continue if the event type is click, because there may not be the tile meta data.
+        // That's why it will be processed in the metalayer click handler.
         if (!metalayer.entity && type !== 'click') {
             return;
         }
 
+        // There is no need to fire metalayer event if the metalayer is undefined.
         if (!metalayer.layer) {
             return;
         }

--- a/src/DGCustomization/src/DGMap.js
+++ b/src/DGCustomization/src/DGMap.js
@@ -214,7 +214,9 @@ DG.Map.include({
         }
 
         var data = {
-            originalEvent: e
+            originalEvent: e,
+            eventTargets: targets,
+            eventTargetsMapIndex: targets.indexOf(this)
         };
 
         if (e.type !== 'keypress') {
@@ -268,6 +270,7 @@ DG.Map.include({
     _getCurrentMetaLayer: function(data) {
         // Not forget for IE8 with srcElement
         var eventTarget = data.originalEvent.target || data.originalEvent.srcElement;
+        var isClick = data.originalEvent.type === 'click';
 
         // Suppose that user can interact with the metalayer only if there are no layers between cursor and map
         if (
@@ -285,6 +288,11 @@ DG.Map.include({
                         layer: this.metaLayers[j],
                         entity: metaEntity
                     };
+                } else if (isClick) {
+                    return {
+                        layer: this.metaLayers[j],
+                        entity: undefined
+                    }
                 }
             }
         }
@@ -295,9 +303,14 @@ DG.Map.include({
     },
 
     _fireMetalayerEvent: function(type, metalayer, data) {
-        if (!metalayer.entity) {
+        if (!metalayer.entity && type !== 'click') {
             return;
         }
+
+        if (!metalayer.layer) {
+            return;
+        }
+
         var listener = metalayer.layer.mapEvents[type];
         if (!listener) {
             return;

--- a/src/DGMeta/src/DGMeta.Layer.js
+++ b/src/DGMeta/src/DGMeta.Layer.js
@@ -186,12 +186,13 @@ DG.Meta.Layer = DG.Layer.extend({
                 layerPoint = this._map.mouseEventToLayerPoint(event.originalEvent),
                 tileOriginPoint = this._map.getPixelOrigin().add(layerPoint),
                 tileCoord = tileOriginPoint.unscaleBy(tileSize).floor(),
-                mouseTileOffset = DG.point(tileOriginPoint.x % tileSize.x, tileOriginPoint.y % tileSize.y),
-                tileKey;
+                mouseTileOffset = DG.point(tileOriginPoint.x % tileSize.x, tileOriginPoint.y % tileSize.y);
             tileCoord.z = this._getZoomForUrl();
             tileCoord.key = tileSize.x + 'x' + tileSize.y;
-            tileKey = this._origin.getTileKey(tileCoord);
+            var tileKey = this._origin.getTileKey(tileCoord);
             var self = this;
+
+            // In this function the tile meta data are processed by metalayer.
             var onTileData = function(currentTileData) {
                 self._currentTileData = currentTileData;
                 self._currentTileKey = tileKey;
@@ -204,6 +205,8 @@ DG.Meta.Layer = DG.Layer.extend({
                 }
             }
 
+            // For more information about the code below see:
+            // https://github.com/2gis/mapsapi/pull/501
             this._origin.getTileData(tileCoord, function(tileData) {
                 if (tileData) {
                     onTileData(tileData);

--- a/src/DGMeta/src/DGMeta.Origin.js
+++ b/src/DGMeta/src/DGMeta.Origin.js
@@ -25,6 +25,7 @@ DG.Meta.Origin = DG.Class.extend({
             self = this,
             callback = typeof clb === 'function' ? clb : function() {};
 
+        // if the tile meta data request in progress, this function returns false, it is therefore synchronous.
         if (typeof this._tileStorage[tileKey] === 'undefined' && typeof this._requests[tileKey] === 'undefined') {
             this._tileStorage[tileKey] = false;
             var currentRequest = this._requests[tileKey] = this._requestData(coord).then(function(data) {


### PR DESCRIPTION
### **Проблема**
Вся проблема была в том, что мета данные тайла появлялись только при срабатывании события на них (например, при наведении курсора мыши на тайл). Поэтому когда быстро кликались пои и данные не успевали подгружаться, событие обрабатывалось в карте и, соответственно, летел гео запрос, в котором приходили все мета объекты в этом тайле. Затем вычислялся hovered мета объект, и если он был, то летел второй запрос на получение данных по нему. Т.е. получалось, что у нас один запрос лишний.
Такая ситуация имеет место из-за метода getTileData() у DG.Meta.Origin, который является синхронным: при наличии данных возвращаются сами данные, если данные не успели подгрузится - возвращается false.

### **Что сделано**
Оставил комментарии в коде, неочевидные моменты - в комментах пулл реквеста.