### PR TITLE
Fix traffic region changing logic

### DIFF
--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -209,7 +209,7 @@ DG.Traffic = DG.TileLayer.extend({
             minZoom: Math.max(project.minZoom, this._layersOptions.minZoom),
             maxZoom: project.maxZoom
         } : {
-            maxZoom: 20,
+            maxZoom: project ? project.maxZoom : DG.config.projectLeaveMaxZoom,
             minZoom: 0
         });
         this._metaLayer.getOrigin().setURL(this._prepareMetaURL());

--- a/src/DGTraffic/src/DGTraffic.js
+++ b/src/DGTraffic/src/DGTraffic.js
@@ -48,7 +48,7 @@ DG.Traffic = DG.TileLayer.extend({
             this._onAddSetParams(map);
         } else {
             var self = this;
-            this._isOnRequest = true; 
+            this._isOnRequest = true;
             this._getTimestampString()
                 .then(
                     function(response) {
@@ -75,14 +75,14 @@ DG.Traffic = DG.TileLayer.extend({
             map
                 .removeLayer(this._metaLayer)
                 .off('projectchange projectleave', this._onMapProjectChange, this);
-    
+
             if (!this.options.disableLabel) {
                 this._metaLayer.off(this._layerEventsListeners, this);
                 this._map.removeLayer(this._labelHelper);
                 this._labelHelper = null;
                 this._map.off('langchange', this._updateLang, this);
             }
-    
+
             DG.TileLayer.prototype.onRemove.call(this, map);
         } else {
             L.DomUtil.remove(this._container);
@@ -209,7 +209,7 @@ DG.Traffic = DG.TileLayer.extend({
             minZoom: Math.max(project.minZoom, this._layersOptions.minZoom),
             maxZoom: project.maxZoom
         } : {
-            maxZoom: 0,
+            maxZoom: 20,
             minZoom: 0
         });
         this._metaLayer.getOrigin().setURL(this._prepareMetaURL());


### PR DESCRIPTION
#### Шаги для воспроизведения бага
1. Открыть демку, например, https://maps.api.2gis.ru/2.0
1. Включить пробки
1. В консоле ввести `map.setView([61.75562, 79.13383])`, чтобы карта уехала в место, где пробок нет
1. Вернуться обратно с помощью `map.setView([54.98015, 82.89744])`
- ОР: пробки показываются
- ФР: пробок нет, хотя контрол пробок показывает, что они включены

### Решение
Фикс занимает всего 1 символ, `maxZoom: 0` я заменил на `maxZoom: 20`. Однако понять, что здесь происходит гораздо сложнее.

Когда карта возвращается обратно в Новосибирск c `DGTraffic` происходят 2 вещи:
1. Из-за изменения вьюпорта у `GridState` (от которого наследуется `DGTraffic`) вызывается метод `_setView`, в котором выставляется поле `_tileZoom`. Поскольку до это сработало событие `projectchange` и [код](https://github.com/2gis/mapsapi/blob/6e568a999123f4077ef85630eb0167a1ad3c6996/src/DGTraffic/src/DGTraffic.js#L211-L214) выставил `minZoom` и `maxZoom` в 0, то 
функция [_setView](https://github.com/Leaflet/Leaflet/blob/b346bb8bf7bb80899baa1f4fc1536bae58e7e3e6/src/layer/tile/GridLayer.js#L504) ставит `_tileZoom` в `undefined`.
2. После этого, когда вьюпорт закончил перемещение, всплывает событие `projectchange`, и вызывается метод `GridState._update`, который должен по идеи снова показать тайлы пробок, но этого [не происходит](https://github.com/Leaflet/Leaflet/blob/b346bb8bf7bb80899baa1f4fc1536bae58e7e3e6/src/layer/tile/GridLayer.js#L598) поскольку `_tileZoom === undefined`.

Простейший фикс этой проблемы заключается в том, чтобы не ограничивать 0 максимальный зум для тайлов пробок в межпроектье.