### PR TITLE
Update heatmap and markercluster plugins

### DIFF
--- a/src/doc/en/examples/external-modules.md
+++ b/src/doc/en/examples/external-modules.md
@@ -13,14 +13,14 @@ Example of clusterer enabling. Clusterer is often used to display big amount of 
 is available on <a href="https://github.com/Leaflet/Leaflet.markercluster" target="_blank">GitHub repository</a> of the author.
 
 <script src="https://maps.api.2gis.ru/2.0/loader.js"></script>
-<link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
-<link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
 <script src="https://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
         // module code loading
-        return DG.plugin('https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/leaflet.markercluster-src.js');
+        return DG.plugin('https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js');
     }).then(function() {
         map = DG.map('map', {
             center: DG.latLng(54.92, 82.82),
@@ -47,8 +47,8 @@ is available on <a href="https://github.com/Leaflet/Leaflet.markercluster" targe
         <head>
             <title>Clusterer</title>
             <script src="https://maps.api.2gis.ru/2.0/loader.js"></script>
-            <link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
-            <link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
             <script src="https://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
         </head>
         <body>
@@ -56,7 +56,7 @@ is available on <a href="https://github.com/Leaflet/Leaflet.markercluster" targe
             <script>
                 DG.then(function() {
                     // module code loading
-                    return DG.plugin('https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/leaflet.markercluster-src.js');
+                    return DG.plugin('https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js');
                 }).then(function() {
                     map = DG.map('map', {
                         center: DG.latLng(54.92, 82.82),
@@ -91,7 +91,7 @@ a geographical region. The color intensity for each region depends on the values
 <script>
     DG.then(function() {
         // Module code loading
-        return DG.plugin('https://2gis.github.io/mapsapi/vendors/HeatLayer/heatLayer.js');
+        return DG.plugin('https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js');
     }).then(function() {
         map = DG.map('map1', {
             center: DG.latLng(54.89, 82.45),
@@ -114,7 +114,7 @@ a geographical region. The color intensity for each region depends on the values
             <script>
                 DG.then(function() {
                     // Module code loading
-                    return DG.plugin('https://2gis.github.io/mapsapi/vendors/HeatLayer/heatLayer.js');
+                    return DG.plugin('https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js');
                 }).then(function() {
                     map = DG.map('map', {
                         center: DG.latLng(54.89, 82.45),

--- a/src/doc/ru/examples/external-modules.md
+++ b/src/doc/ru/examples/external-modules.md
@@ -13,14 +13,14 @@
 Код модуля и его документация доступна в <a href="https://github.com/Leaflet/Leaflet.markercluster" target="_blank">GitHub-репозитории</a> автора.
 
 <script src="https://maps.api.2gis.ru/2.0/loader.js"></script>
-<link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
-<link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
 <script src="https://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
 <div id="map" style="width: 100%; height: 400px;"></div>
 <script>
     DG.then(function() {
         // загрузка кода модуля
-        return DG.plugin('https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/leaflet.markercluster-src.js');
+        return DG.plugin('https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js');
     }).then(function() {
         map = DG.map('map', {
             center: DG.latLng(54.92, 82.82),
@@ -46,8 +46,8 @@
         <head>
             <title>Кластеризатор</title>
             <script src="https://maps.api.2gis.ru/2.0/loader.js"></script>
-            <link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.css" />
-            <link rel="stylesheet" href="https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/MarkerCluster.Default.css" />
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
             <script src="https://maps.api.2gis.ru/2.0/cluster_realworld.js"></script>
         </head>
         <body>
@@ -55,7 +55,7 @@
             <script>
                 DG.then(function() {
                     // загрузка кода модуля
-                    return DG.plugin('https://2gis.github.io/mapsapi/vendors/Leaflet.markerCluster/leaflet.markercluster-src.js');
+                    return DG.plugin('https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js');
                 }).then(function() {
                     map = DG.map('map', {
                         center: DG.latLng(54.92, 82.82),
@@ -90,7 +90,7 @@
 <script>
     DG.then(function() {
         // загрузка кода модуля
-        return DG.plugin('https://2gis.github.io/mapsapi/vendors/HeatLayer/heatLayer.js');
+        return DG.plugin('https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js');
     }).then(function() {
         map = DG.map('map1', {
             center: DG.latLng(54.89, 82.45),
@@ -113,7 +113,7 @@
             <script>
                 DG.then(function() {
                     // загрузка кода модуля
-                    return DG.plugin('https://2gis.github.io/mapsapi/vendors/HeatLayer/heatLayer.js');
+                    return DG.plugin('https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js');
                 }).then(function() {
                     map = DG.map('map', {
                         center: DG.latLng(54.89, 82.45),


### PR DESCRIPTION
Обновил в примерах про подключение плагинов сторонние модули, чтобы пользователи брали не устаревшие версии с нашего гитхаба, а нормально работающие с unpkg.

При этом удалять лежащие у нас плагины нельзя, поскольку многие их у себя заиспользовали.