### PR TITLE
Track geometries usage with analytics

### DIFF
--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -61,7 +61,7 @@ L.Canvas.include({
 // TODO: remove after successful research
 if (DG.Path) {
     var pathInitialize = DG.Path.prototype.onAdd;
-    var logedGeometryTypes = {};
+    var loggedGeometryTypes = {};
 
     DG.Path.include({
         onAdd: function(map) {
@@ -80,8 +80,8 @@ if (DG.Path) {
             }
 
             // Don't send event twice for same type
-            if (!logedGeometryTypes[type]) {
-                logedGeometryTypes[type] = true;
+            if (!loggedGeometryTypes[type]) {
+                loggedGeometryTypes[type] = true;
 
                 if (typeof ga !== undefined) {
                     // eslint-disable-next-line no-undef

--- a/src/DGCustomization/src/DGCustomization.js
+++ b/src/DGCustomization/src/DGCustomization.js
@@ -56,3 +56,40 @@ L.Canvas.include({
         this._ctx = container.getContext('2d');
     }
 });
+
+// Monitor geometry usage
+// TODO: remove after successful research
+if (DG.Path) {
+    var pathInitialize = DG.Path.prototype.onAdd;
+    var logedGeometryTypes = {};
+
+    DG.Path.include({
+        onAdd: function(map) {
+            var type = 'Unknown';
+
+            if (DG.Rectangle && this instanceof DG.Rectangle) {
+                type = 'Rectangle';
+            } else if (DG.Circle && this instanceof DG.Circle) {
+                type = 'Circle';
+            } else if (DG.CircleMarker && this instanceof DG.CircleMarker) {
+                type = 'CircleMarker'
+            } else if (DG.Polygon && this instanceof DG.Polygon) {
+                type = 'Polygon';
+            } else if (DG.Polyline && this instanceof DG.Polyline) {
+                type = 'Polyline';
+            }
+
+            // Don't send event twice for same type
+            if (!logedGeometryTypes[type]) {
+                logedGeometryTypes[type] = true;
+
+                if (typeof ga !== undefined) {
+                    // eslint-disable-next-line no-undef
+                    ga(DG.config.gaName + '.send', 'event', 'Geometry', 'Use', type);
+                }
+            }
+
+            return pathInitialize.call(this, map);
+        },
+    });
+}


### PR DESCRIPTION
Добавил отслеживание события по использованию геометрий.

Поскольку геометрий на карту можно добавить в большом количестве, то сделал так, чтобы события отправлялись только 1 раз для каждого типа геометрии.

Тип геометрии приходится опредлеять перебором через `instanceof`, посколько так проще, чем патчить прототип геометрии каждого типа.