### PR TITLE
fix ruler initialization

### DIFF
--- a/src/DGRuler/src/Ruler.js
+++ b/src/DGRuler/src/Ruler.js
@@ -10,7 +10,7 @@ DG.Ruler = DG.Layer.extend({
         Dictionary: {}
     },
 
-    initialize: function(latlngs, options) { // (Array, Object)
+    initialize: function(options) { // (Object)
         DG.Util.setOptions(this, options);
 
         this._layers = {
@@ -34,10 +34,6 @@ DG.Ruler = DG.Layer.extend({
             delete this._lineMouseEvents.mousemove;
         } else {
             delete this._lineMouseEvents.click;
-        }
-
-        if (latlngs && latlngs.length) {
-            this.setLatLngs(latlngs);
         }
     },
 

--- a/src/doc/en/manual/dg-ruler.md
+++ b/src/doc/en/manual/dg-ruler.md
@@ -15,8 +15,10 @@ Create and display a ruler on the map:
         [51.7307, 36.1894],
         [51.7297, 36.1926],
         [51.7299, 36.1968],
-        [51.7307, 36.1968]]
-    DG.ruler(latLngs).addTo(map);
+        [51.7307, 36.1968]
+    ];
+
+    DG.ruler().addTo(map).setLatLngs(latLngs);
 
 #### Creation
 
@@ -31,11 +33,10 @@ Create and display a ruler on the map:
     <tbody>
         <tr>
             <td><code><b>DG.Ruler</b>(
-                <nobr>&lt;<a href="/doc/maps/en/manual/basic-types#dglatlng">LatLng</a>[]&gt; <i>latlngs</i>,</nobr>
                 <nobr>&lt;<a href="#dgruler-options">Ruler options</a>&gt; <i>options?</i> )</nobr>
             </code></td>
             <td><code>DG.ruler(&hellip;)</code></td>
-            <td>Creates the ruler object by the given array of geographical points and optional object of options.</td>
+            <td>Creates the ruler instance by the given optional object of options.</td>
         </tr>
     </tbody>
 </table>

--- a/src/doc/ru/manual/dg-ruler.md
+++ b/src/doc/ru/manual/dg-ruler.md
@@ -15,8 +15,10 @@
         [51.7307, 36.1894],
         [51.7297, 36.1926],
         [51.7299, 36.1968],
-        [51.7307, 36.1968]]
-    DG.ruler(latLngs).addTo(map);
+        [51.7307, 36.1968]
+    ];
+
+    DG.ruler().addTo(map).setLatLngs(latLngs);
 
 #### Создание
 
@@ -31,11 +33,10 @@
     <tbody>
         <tr>
             <td><code><b>DG.Ruler</b>(
-                <nobr>&lt;<a href="/doc/maps/ru/manual/basic-types#dglatlng">LatLng</a>[]&gt; <i>latlngs</i>,</nobr>
                 <nobr>&lt;<a href="#dgruler-options">Ruler options</a>&gt; <i>options?</i> )</nobr>
             </code></td>
             <td><code>DG.ruler(&hellip;)</code></td>
-            <td>Создает объект линейки по переданному массиву географических точек и необязательному объекту опций.</td>
+            <td>Создает объект линейки по необязательному объекту опций.</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Сейчас при добавлении точек в линейку при ее ините вызвается метод карты `getLang()`:

https://github.com/2gis/mapsapi/blob/master/src/DGRuler/src/Ruler.js#L342

Поэтому если линейка в карту не добавлена, то словим ошибку.

В PR убрал возможность добавления точек при ините линейки.