### PR TITLE
Fix preview flickering on iOS devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "2gis-maps",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gis-maps",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Interactive 2GIS maps API, based on Leaflet",
   "license": "SEE LICENSE IN FILE",
   "keywords": [

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -368,7 +368,7 @@ L.MobileTileLayer = L.TileLayer.extend({
         var needPreview = this._needPreviewTile(wrapCoords);
 
         var url = needPreview ? this._previewUrl : this._url;
-        var tile = this.createTile(wrapCoords, L.bind(this._tileReady, this, coords), url);
+        var tile = this.createTile(wrapCoords, L.bind(needPreview ? this._previewReady : this._tileReady, this, coords), url);
 
         this._initTile(tile);
 
@@ -391,6 +391,21 @@ L.MobileTileLayer = L.TileLayer.extend({
         });
     },
 
+    _previewReady: function (coords, err, tile) {
+        if (!this._map) { return; }
+
+        var key = this._tileCoordsToKey(coords);
+
+        tile = this._tiles[key];
+        if (!tile) { return; }
+
+
+        tile.el.onload = L.bind(this._tileReady, this, coords, err, tile);
+        tile.el.onerror = L.bind(this._tileReady, this, coords, err, tile);
+        tile.el.src = this.getTileUrl(coords, this._url);
+    },
+
+
     /**
      * Убран fadeAnimated и класс leaflet-tile-loaded
      */
@@ -411,23 +426,6 @@ L.MobileTileLayer = L.TileLayer.extend({
 
         tile = this._tiles[key];
         if (!tile) { return; }
-
-        // Если у тайла уже есть оригинальная (не пожатая) картинка,
-        // то заменим превью на нее
-        if (tile.originalEl && tile.el.parentNode) {
-            tile.el.parentNode.replaceChild(tile.originalEl, tile.el);
-            tile.el = tile.originalEl;
-
-            tile.originalEl = null;
-            tile.preview = false;
-
-        // Если у тайла есть только превью, то добавим его на карту
-        // И начнем грузить оригинальный
-        } else if (tile.preview) {
-            tile.originalEl = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords), this._url);
-            this._initTile(tile.originalEl);
-            L.DomUtil.setPosition(tile.originalEl, this._getTilePos(coords));
-        }
 
         tile.loaded = +new Date();
         tile.active = true;

--- a/src/DGCustomization/src/DGMobileImprove.js
+++ b/src/DGCustomization/src/DGMobileImprove.js
@@ -391,7 +391,7 @@ L.MobileTileLayer = L.TileLayer.extend({
         });
     },
 
-    _previewReady: function (coords, err, tile) {
+    _previewReady: function(coords, err, tile) {
         if (!this._map) { return; }
 
         var key = this._tileCoordsToKey(coords);


### PR DESCRIPTION
Tile transition between previewUrl and url was made by exchanging <img /> elements. On latest iOS devices thus causes tile flicker. 

To avoid flickering, transition between previewUrl and url is implemented via setting 'src' attribute.

Tested in iOS 14 device and Android 8 (Nokia 5.1)