### PR TITLE
Поправил логику показа кнопки "Все организации"

### DIFF
--- a/src/DGGeoclicker/src/handler/House.View.js
+++ b/src/DGGeoclicker/src/handler/House.View.js
@@ -83,13 +83,14 @@ DG.Geoclicker.Handler.House.include({
     _fillFooter: function(house) { // (Object) -> (HTMLString)
         var btns = [];
         var houseFilials = house.links && house.links.branches;
+        var filialsItemsCount = houseFilials &&
+        houseFilials.items &&
+        houseFilials.items.length || 0;
 
         // Decide if we need to display 'more organisations' button
         if (
             houseFilials &&
-            houseFilials.items &&
-            houseFilials.items.length &&
-            houseFilials.count > houseFilials.items.length
+            houseFilials.count > filialsItemsCount
         ) {
             btns.push(this._getShowAllData(houseFilials.count));
         }

--- a/src/DGGeoclicker/src/handler/House.js
+++ b/src/DGGeoclicker/src/handler/House.js
@@ -108,7 +108,9 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
 
         options.firmCard.backBtn = DG.bind(this._showListPopup, this);
 
-        this._shortFirmList._toggleEventHandlers(true);
+        if (this._shortFirmList) {
+            this._shortFirmList._toggleEventHandlers(true);
+        }
 
         this._firmList = new FirmCard.List(results, options);
 
@@ -164,7 +166,9 @@ DG.Geoclicker.Handler.House = DG.Geoclicker.Handler.Default.extend({
     _showHousePopup: function() {
         this._popup.off('scroll', this._onScroll);
         this._clearAndRenderPopup(this._houseObject);
-        this._shortFirmList._toggleEventHandlers();
+        if (this._shortFirmList) {
+            this._shortFirmList._toggleEventHandlers();
+        }
     },
 
     _onFirmListClick: function() {


### PR DESCRIPTION
Поправил логику показа кнопки "Все организации" в попапе. Теперь кнопка отображается даже, если поле `house.links.items` вовсе отсутстует.