### PR TITLE
fix: typo in method `getProjectsList`

### DIFF
--- a/src/doc/en/manual/dg-project-detector.md
+++ b/src/doc/en/manual/dg-project-detector.md
@@ -55,7 +55,7 @@ Subscribe to the projectleave event:
     </thead>
     <tbody>
         <tr>
-            <td>getProjectList</td>
+            <td>getProjectsList</td>
             <td>Object</td>
             <td>Returns all available projects.</td>
         </tr>

--- a/src/doc/ru/manual/dg-project-detector.md
+++ b/src/doc/ru/manual/dg-project-detector.md
@@ -55,7 +55,7 @@
     </thead>
     <tbody>
         <tr>
-            <td>getProjectList</td>
+            <td>getProjectsList</td>
             <td>Object</td>
             <td>Возвращает все доступные проекты.</td>
         </tr>


### PR DESCRIPTION
[method](https://github.com/2gis/mapsapi/blob/905f96b57b6bed8aa80df2ec5ad4962ecc6600bc/src/DGProjectDetector/src/DGProjectDetector.js#L23)