### PR TITLE
Added the 'protocol' option for tiles requests

### DIFF
--- a/src/DGCustomization/src/DGMap.BaseLayer.js
+++ b/src/DGCustomization/src/DGMap.BaseLayer.js
@@ -21,13 +21,19 @@ DG.Map.addInitHook(function() {
     var showCommPoi = (this.options.showCommPoi ? '' : '&layerType=nc');
     validator.validateKeyResponse();
 
-    var tileUrl = DG.config.secureProtocol + (DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer) + showCommPoi;
-    var arabicTileUrl = DG.config.secureProtocol +
+    let protocol = this.options.protocol || DG.config.secureProtocol;
+    // Check that last symbol is colon, and if not add it
+    if (protocol[protocol.length - 1] !== ':') {
+        protocol = protocol + ':';
+    }
+
+    var tileUrl = protocol + (DG.Browser.retina ? DG.config.retinaTileServer : DG.config.tileServer) + showCommPoi;
+    var arabicTileUrl = protocol +
         (DG.Browser.retina ? DG.config.arabicRetinaTileServer : DG.config.arabicTileServer) + showCommPoi;
 
-    var previewTileUrl = DG.config.secureProtocol +
+    var previewTileUrl = protocol +
         (DG.Browser.retina ? DG.config.previewRetinaTileServer : DG.config.previewTileServer) + showCommPoi;
-    var arabicPreviewTileUrl = DG.config.secureProtocol +
+    var arabicPreviewTileUrl = protocol +
         (DG.Browser.retina ? DG.config.arabicPreviewRetinaTileServer : DG.config.arabicPreviewTileServer) + showCommPoi;
 
     this.baseLayer = new BaseLayer(tileUrl, {

--- a/src/doc/en/manual/map.md
+++ b/src/doc/en/manual/map.md
@@ -66,6 +66,13 @@ Initialize the map on the &quot;map&quot; div with a given center and zoom:
                 rendered in a <a href="/doc/maps/en/manual/vector-layers#dgsvg"><code>SVG</code></a> renderer.
             </td>
         </tr>
+        <tr id="map-protocol">
+            <td><code><b>protocol</b></code></td>
+            <td><code>String </code></td>
+            <td><code>''</code></td>
+            <td>Network protocol used in tiles requests.
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/doc/ru/manual/map.md
+++ b/src/doc/ru/manual/map.md
@@ -67,6 +67,13 @@
                 отрисовываются с помощью <a href="/doc/maps/ru/manual/vector-layers#dgsvg"><code>SVG</code></a> рендерера.
             </td>
         </tr>
+        <tr id="map-protocol">
+            <td><code><b>protocol</b></code></td>
+            <td><code>String </code></td>
+            <td><code>''</code></td>
+            <td>Сетевой проток, используемый в запросах к тайлам.
+            </td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
Добавлена опция карты `protocol`.

Если она задана, то используется именно этот протокол.  
Если опция не задача, то используется DG.config.secureProtocol (сейчас это `https`)